### PR TITLE
feat: Modal 컴포넌트 #2

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,46 +1,55 @@
 import { ComponentProps, useRef } from 'react';
 
 // Modal 컴포넌트 사용 예시
-// <Modal width="w-80" actionText="답변 작성하러 가기" cancelText="되돌아가기">아직 답변을 등록하지 않았어요.</Modal>
+// <Modal width="w-80" actionText="답변 작성하러 가기" handleAction={이벤트핸들러} cancelText="되돌아가기">아직 답변을 등록하지 않았어요.</Modal>
 
 type ModalProps = ComponentProps<'div'> & {
   actionText: string;
   cancelText: string;
   width: string;
+  handleAction: () => void;
 };
 
-export default function Modal({ width, actionText, cancelText, children}: ModalProps) {
+export default function Modal({
+  width,
+  actionText,
+  cancelText,
+  handleAction,
+  children,
+}: ModalProps) {
   const modalRef = useRef<HTMLDialogElement>(null);
 
   const handleModalClose = () => {
-    modalRef.current?.close()
-  }
+    modalRef.current?.close();
+  };
 
   const handleModalOpen = () => {
-    modalRef.current?.showModal()
-  }
-
-  const handleAction = () => {
-    modalRef.current?.close()
-    // 답변 작성 액션 or 수정 액션
-  }
+    modalRef.current?.showModal();
+  };
 
   return (
     <>
       <div className="w-full h-full bg-secondary" onClick={handleModalOpen}>
-      🔒 질문 
+        🔒 질문
       </div>
       <dialog ref={modalRef} className="modal">
         <div className={`modal-box ${width}`}>
           <p className="py-4">{children}</p>
           <div className="flex flex-row justify-between">
-          <button className="btn w-28 btn-secondary" onClick={handleModalClose}>{cancelText}</button>
-          <button className="btn w-28 btn-primary" onClick={handleAction}>{actionText}</button>
+            <button
+              className="btn w-28 btn-secondary"
+              onClick={handleModalClose}
+            >
+              {cancelText}
+            </button>
+            <button className="btn w-28 btn-primary" onClick={handleAction}>
+              {actionText}
+            </button>
           </div>
         </div>
         <form method="dialog" className="modal-backdrop">
           <button>close</button>
-        </form>        
+        </form>
       </dialog>
     </>
   );

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,47 @@
+import { ComponentProps, useRef } from 'react';
+
+// Modal 컴포넌트 사용 예시
+// <Modal width="w-80" actionText="답변 작성하러 가기" cancelText="되돌아가기">아직 답변을 등록하지 않았어요.</Modal>
+
+type ModalProps = ComponentProps<'div'> & {
+  actionText: string;
+  cancelText: string;
+  width: string;
+};
+
+export default function Modal({ width, actionText, cancelText, children}: ModalProps) {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  const handleModalClose = () => {
+    modalRef.current?.close()
+  }
+
+  const handleModalOpen = () => {
+    modalRef.current?.showModal()
+  }
+
+  const handleAction = () => {
+    modalRef.current?.close()
+    // 답변 작성 액션 or 수정 액션
+  }
+
+  return (
+    <>
+      <div className="w-full h-full bg-secondary" onClick={handleModalOpen}>
+      🔒 질문 
+      </div>
+      <dialog ref={modalRef} className="modal">
+        <div className={`modal-box ${width}`}>
+          <p className="py-4">{children}</p>
+          <div className="flex flex-row justify-between">
+          <button className="btn w-28 btn-secondary" onClick={handleModalClose}>{cancelText}</button>
+          <button className="btn w-28 btn-primary" onClick={handleAction}>{actionText}</button>
+          </div>
+        </div>
+        <form method="dialog" className="modal-backdrop">
+          <button>close</button>
+        </form>        
+      </dialog>
+    </>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#2 

## 📝작업 내용

- 공통적으로 사용될 모달 컴포넌트를 작업했습니다.

- prop은 4종류가 있으며, 아래와 같습니다.
  - width(모달창의 너비)
  - actionText(액션 버튼에 넣을 텍스트)
  - cancelText(취소 버튼에 넣을 텍스트)
  - handleAction(액션 버튼 클릭시에 트리거되는 함수)

- Modal 컴포넌트 사용 예시는 아래와 같습니다.
  ```tsx
  <Modal 
    width="w-80" 
    actionText="답변 작성하러 가기" 
    handleAction={이벤트핸들러} 
    cancelText="되돌아가기"
  >
    아직 답변을 등록하지 않았어요.
  </Modal>
  ```

### 스크린샷 
<img width="1045" alt="스크린샷 2023-12-05 오후 5 50 24" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/783d2212-ff3d-4fee-be9f-2fbb320986cb">


## 💬리뷰 요구사항

1. 모달의 액션 버튼에 들어갈 텍스트 '답변 작성하러가기'가 너무 긴 것이 아닌가 하는 고민이 들었습니다. 모달에 관련된 부분은 아니지만, 나중에 고려해봐야 할 것 같습니다. 
2. 현재 모달 재사용을 위해 생각해둔 prop으로 위의 4가지가 있는데, 더 고려해야 할 사항이 있을지 궁금합니다. 혹시 생각하시는 것이 있다면 알려주세요!