### PR TITLE
feat: text input(UI 컴포넌트) 구현 (#6)

### DIFF
--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -1,0 +1,27 @@
+import { ChangeEvent, ComponentProps } from 'react';
+
+type TextInputProps = ComponentProps<'input'> & {
+  value: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+};
+
+const TextInput = ({
+  value,
+  onChange,
+  className,
+  ...props
+}: TextInputProps) => {
+  return (
+    <div className="flex flex-row items-center justify-center">
+      <input
+        className={`input w-[90%] rounded-xl border-1 border-[black] m-2 ${className}`}
+        type="text"
+        value={value}
+        onChange={onChange}
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default TextInput;

--- a/src/pages/register-questions/index.tsx
+++ b/src/pages/register-questions/index.tsx
@@ -1,0 +1,18 @@
+import BottomNavigation from '@/components/layout/BottomNavigation';
+import TextInput from '@/components/ui/TextInput';
+import { useState, ChangeEvent } from 'react';
+
+export default function Page() {
+  const [text, setText] = useState('');
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setText(e.target.value);
+  };
+
+  return (
+    <div>
+      <TextInput value={text} onChange={onChange} />
+      <BottomNavigation />
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
#6 

## 📝작업 내용
질문 등록 폼에서 쓰이는 text input을 작업했습니다. 

prop으로 value, onChange를 받습니다.

<img width="512" alt="image" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/711d6b85-2b76-41c7-9582-494f399c5b34">

## 💬리뷰 요구사항

- 한 곳에서만 쓰이는 컴포넌트이기 때문에 재사용성을 크게 고려하지 않았습니다. TextInput 컴포넌트에 className을 넣으면 기존의 스타일을 덮는 방식으로 스타일이 적용됩니다. 