### PR TITLE
feat: list item 컴포넌트 추가 (#4)

### DIFF
--- a/src/components/ui/ListItem.tsx
+++ b/src/components/ui/ListItem.tsx
@@ -1,0 +1,13 @@
+type ListItemProps = {
+  question: string;
+};
+
+const ListItem = ({ question }: ListItemProps) => {
+  return (
+    <div className="flex flex-col justify-center border-2 border-[black] rounded-lg bg-secondary h-20 w-[80%] m-1 p-2">
+      {question}
+    </div>
+  );
+};
+
+export default ListItem;

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -1,9 +1,28 @@
 import BottomNavigation from '@/components/layout/BottomNavigation';
+import ListItem from '@/components/ui/ListItem';
+
+const dummyQuestionList = [
+  {
+    questionId: 1,
+    question: '같이 해보고 싶은 버킷리스트가 있나요?',
+  },
+  {
+    questionId: 2,
+    question: '다툼이 생겼을 때 절대 안 했으면 하는 것이 있다면 무엇인가요?',
+  },
+];
 
 export default function Page() {
   return (
     <div>
-      questionList
+      {dummyQuestionList.map((question) => (
+        <div
+          key={question.questionId}
+          className="flex flex-col justify-center items-center"
+        >
+          <ListItem question={question.question} />
+        </div>
+      ))}
       <BottomNavigation />
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

#4 

## 📝작업 내용
질문 선택 페이지에서 선택할 수 있는 질문 아이템 컴포넌트입니다. 

api를 참고하여 만든 더미데이터를 questions 페이지에서 map을 통해 해당 컴포넌트로 넘겨주면 아래 스크린샷과 같은 질문 아이템들을 확인할 수 있습니다. 
<img width="507" alt="image" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/0ee5968f-ffdc-4a5b-aeb5-0980999df27a">