### PR TITLE
Feature/invite page

### DIFF
--- a/src/components/ui/ListItem.tsx
+++ b/src/components/ui/ListItem.tsx
@@ -1,10 +1,13 @@
 type ListItemProps = {
   question: string;
+  className?: string;
 };
 
-const ListItem = ({ question }: ListItemProps) => {
+const ListItem = ({ question, className }: ListItemProps) => {
   return (
-    <div className="flex flex-col justify-center border-2 border-[black] rounded-lg bg-secondary h-20 w-[80%] m-1 p-2">
+    <div
+      className={`flex flex-col justify-center border-2 border-[black] rounded-lg bg-secondary h-20 w-[80%] m-1 p-2 ${className}`}
+    >
       {question}
     </div>
   );

--- a/src/components/ui/TextArea.tsx
+++ b/src/components/ui/TextArea.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from 'react';
 type TextAreaProps = ComponentProps<'textarea'> & {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  className?: string;
 };
 
 export default function TextArea({
@@ -13,7 +14,7 @@ export default function TextArea({
 }: TextAreaProps) {
   return (
     <textarea
-      className="block w-[90%] mx-auto min-h-[20rem] textarea rounded-xl border-1 border-gray-dark text-base"
+      className={`block w-[90%] mx-auto min-h-[20rem] textarea rounded-xl border-1 border-gray-dark text-base ${className}`}
       value={value}
       onChange={onChange}
       {...props}

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -1,0 +1,44 @@
+import type { NextPageWithLayout } from '@/types/page';
+import BasicLayout from '@/components/layout/BasicLayout';
+import Image from 'next/image';
+import ListItem from '@/components/ui/ListItem';
+import TextArea from '@/components/ui/TextArea';
+import Button from '@/components/ui/Button';
+
+const question = '같이 해보고 싶은 버킷리스트가 있나요?';
+const Page: NextPageWithLayout = () => {
+  return (
+    <>
+      <div className="mt-10">
+        <div>
+          {'{'}memberName{'}'}이
+        </div>
+        <div>초대 링크를 보냈어요!</div>
+      </div>
+      <ListItem question={question} className="bg-white mt-5" />
+      <Image
+        src="/logo.png"
+        priority
+        alt="service-logo"
+        width="100"
+        height="100"
+        style={{ margin: '1rem' }}
+      />
+      <div className="mb-5">
+        <div>답변을 작성해 볼까요?</div>
+      </div>
+      <TextArea value="" onChange={() => {}} className="min-h-[15rem]" />
+      <Button variant="primary" size="wide" className="mt-5">
+        답변 등록
+      </Button>
+    </>
+  );
+};
+
+Page.getLayout = function getLayout(page) {
+  return (
+    <BasicLayout className="bg-[#F7CBC3] justify-center">{page}</BasicLayout>
+  );
+};
+
+export default Page;


### PR DESCRIPTION
## #️⃣연관된 이슈

#30 

## 📝작업 내용
초대 링크 렌딩 페이지를 구현하였습니다.

list item 컴포넌트, textarea 컴포넌트, button 컴포넌트를 사용하였습니다.

<img width="715" alt="image" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/c3845104-9495-4c6b-a75a-5d54efc60276">

### 기타
TextArea 컴포넌트를 사용하다가 prop으로 받은 `className`을 TextArea 컴포넌트에서 사용하고 있지 않다는 것을 발견하였습니다. 그래서 TextArea 컴포넌트의 className에 이를 적용하는 부분을 추가하였습니다. 