### PR TITLE
Feature/auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/src/components/ui/KakaoLoginButton.tsx
+++ b/src/components/ui/KakaoLoginButton.tsx
@@ -2,13 +2,9 @@ import type { ComponentProps } from 'react';
 import Button from './Button';
 import KakaoIcon from '@/components/icons/KakaoIcon';
 import Link from 'next/link';
+import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
 
 type ButtonProps = ComponentProps<'button'>;
-
-const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오 개발자 콘솔에서 발급받은 REST API 키
-const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI; // 카카오로부터 인증 응답을 받을 서버의 URI
-
-const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
 
 export default function KakaoLoginButton({ ...props }: ButtonProps) {
   const kakaoStyle = `bg-[#FEE400] hover:bg-[#FEE400] border-[#FEE400] hover:border-[#FEE400] text-[#371C1D]`;

--- a/src/components/ui/KakaoLoginButton.tsx
+++ b/src/components/ui/KakaoLoginButton.tsx
@@ -1,20 +1,28 @@
 import type { ComponentProps } from 'react';
 import Button from './Button';
 import KakaoIcon from '@/components/icons/KakaoIcon';
+import Link from 'next/link';
 
 type ButtonProps = ComponentProps<'button'>;
+
+const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오 개발자 콘솔에서 발급받은 REST API 키
+const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI; // 카카오로부터 인증 응답을 받을 서버의 URI
+
+const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
 
 export default function KakaoLoginButton({ ...props }: ButtonProps) {
   const kakaoStyle = `bg-[#FEE400] hover:bg-[#FEE400] border-[#FEE400] hover:border-[#FEE400] text-[#371C1D]`;
   return (
-    <Button
-      className={`${kakaoStyle} flex items-center justify-center`}
-      size="wide"
-      variant="primary"
-      {...props}
-    >
-      <KakaoIcon className="w-6 h-6" />
-      카카오 로그인
-    </Button>
+    <Link href={KAKAO_AUTH_URL} className="w-full">
+      <Button
+        className={`${kakaoStyle} flex items-center justify-center`}
+        size="wide"
+        variant="primary"
+        {...props}
+      >
+        <KakaoIcon className="w-6 h-6" />
+        카카오 로그인
+      </Button>
+    </Link>
   );
 }

--- a/src/constants/kakaoAuth.ts
+++ b/src/constants/kakaoAuth.ts
@@ -1,0 +1,4 @@
+const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오 개발자 콘솔에서 발급받은 REST API 키
+const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI; // 카카오로부터 인증 응답을 받을 서버의 URI
+
+export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -1,0 +1,4 @@
+export const LOCAL_STORAGE_KEYS = {
+  PREV_URL: 'prevUrl',
+  TOKEN: 'youare-iam-token',
+};

--- a/src/pages/login/kakao/index.tsx
+++ b/src/pages/login/kakao/index.tsx
@@ -1,0 +1,34 @@
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+export default function Login() {
+  const router = useRouter();
+  const { code } = router.query;
+
+  useEffect(() => {
+    console.log(code);
+    const fetchToken = async () => {
+      try {
+        const res = await axios.get(
+          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/members/kakao/callback?code=${code}`
+        );
+        console.log(res);
+        console.log(res.headers['authorization']);
+
+        localStorage.setItem('jwt', res.headers['authorization']);
+        // Todo: 다른 페이지로 리다이렉트하도록 하기 (ex: onboarding, main, 초대링크랜딩페이지)
+        // router.push('/onboarding');
+      } catch (err) {
+        console.error(err);
+        alert('An error occurred while logging in. Please try again.');
+      }
+    };
+
+    if (code) {
+      fetchToken();
+    }
+  }, [code, router]);
+
+  return <div>redirecting...</div>;
+}

--- a/src/pages/login/kakao/index.tsx
+++ b/src/pages/login/kakao/index.tsx
@@ -1,9 +1,10 @@
-import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
-import axios from 'axios';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 
 export default function Login() {
+  const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const { code } = router.query;
 
@@ -24,8 +25,7 @@ export default function Login() {
         router.push(prevUrl || '/onboarding');
         localStorage.removeItem(LOCAL_STORAGE_KEYS.PREV_URL);
       } catch (err) {
-        console.error(err);
-        alert('An error occurred while logging in. Please try again.');
+        setError('로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
       }
     };
 
@@ -34,5 +34,5 @@ export default function Login() {
     }
   }, [code, router]);
 
-  return <div></div>;
+  return <div>{error && <p>{error}</p>}</div>;
 }

--- a/src/pages/login/kakao/index.tsx
+++ b/src/pages/login/kakao/index.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import axios from 'axios';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -7,18 +8,21 @@ export default function Login() {
   const { code } = router.query;
 
   useEffect(() => {
-    console.log(code);
+    console.log(router.asPath);
     const fetchToken = async () => {
       try {
         const res = await axios.get(
           `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/members/kakao/callback?code=${code}`
         );
-        console.log(res);
-        console.log(res.headers['authorization']);
 
-        localStorage.setItem('jwt', res.headers['authorization']);
-        // Todo: 다른 페이지로 리다이렉트하도록 하기 (ex: onboarding, main, 초대링크랜딩페이지)
-        // router.push('/onboarding');
+        localStorage.setItem(
+          LOCAL_STORAGE_KEYS.TOKEN,
+          res.headers['authorization']
+        );
+
+        const prevUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.PREV_URL);
+        router.push(prevUrl || '/onboarding');
+        localStorage.removeItem(LOCAL_STORAGE_KEYS.PREV_URL);
       } catch (err) {
         console.error(err);
         alert('An error occurred while logging in. Please try again.');
@@ -30,5 +34,5 @@ export default function Login() {
     }
   }, [code, router]);
 
-  return <div>redirecting...</div>;
+  return <div></div>;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #46 

## 📝작업 내용

- [X] 카카오 인증 페이지로 사용자 리디렉션 
- [X] 카카오 로그인 + 사용 동의 과정 이후 리디렉션 
- [X] 리디렉션 페이지에서 url 파라미터에 있는 인증 코드를 백엔드 서버에 보내 액세스 토큰 요청 

### 구현이 아직 안된 부분 
- 인증되지 않은 사용자가 사용할 수 없는 라우트 처리 - protectedRoute 
- axios intercepter request header에 클라이언트사이드에 저장된 토큰을 붙이는 부분 

구현되지 않은 부분은 이슈를 새로 만들어서 진행하겠습니다! 

다른 페이지에서 로그인을 구현하실때는 아래의 내용을 참고해주세요! 
1. 카카오인증 페이지는 상수로 처리했습니다. 로그인이 필요한 사용자를 해당 url로 이동시켜주세요 
https://github.com/coding-union-kr/youare-iam-fe/blob/4c6a0210420a5d70bdce0eefe5cec7304a210304/src/constants/kakaoAuth.ts#L1-L4

2. 로그인 이후에 사용자가 다시 돌아와야하는 페이지(초대링크 랜딩페이지)의 path를 localstorage에 저장을 하고 이동시켜주세요. 
```tsx
const router = useRouter();
 useEffect(() => {
    window.localStorage.setItem(LOCAL_STORAGE_KEYS.PREV_URL, router.asPath);
  }, []);
```
