### PR TITLE
Feature/에러 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "14.0.3",
         "react": "^18",
         "react-dom": "^18",
+        "react-error-boundary": "^4.0.12",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -58,7 +59,6 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
       "integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -3734,6 +3734,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -3803,8 +3814,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
-      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==",
-      "dev": true
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.10.0",
-    "axios": "^1.6.2",
     "@tanstack/react-query-devtools": "^5.13.5",
+    "axios": "^1.6.2",
     "next": "14.0.3",
     "react": "^18",
     "react-dom": "^18",
+    "react-error-boundary": "^4.0.12",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/components/error/ErrorFallback.tsx
+++ b/src/components/error/ErrorFallback.tsx
@@ -1,0 +1,25 @@
+import Button from '../ui/Button';
+
+type ErrorFallbackProp = {
+  resetErrorBoundary: (...args: any[]) => void;
+};
+
+const ErrorFallback = ({ resetErrorBoundary }: ErrorFallbackProp) => {
+  return (
+    <section>
+      <div className="h-screen flex flex-col items-center pt-20">
+        <div className="font-neo text-lg mb-4">에러가 발생했어요! </div>
+        <Button
+          variant="secondary"
+          size="normal"
+          onClick={resetErrorBoundary}
+          font-neo
+        >
+          다시 시도하기
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default ErrorFallback;

--- a/src/components/layout/BottomNavigation.tsx
+++ b/src/components/layout/BottomNavigation.tsx
@@ -18,12 +18,12 @@ export type NavIconProps = ComponentProps<'svg'> & {
 const NAV_ITEMS = [
   { href: '/chatroom', Icon: ChatRoomIcon, label: '대화상세' },
   { href: '/questions', Icon: SelectIcon, label: '질문선택' },
-  { href: '/status', Icon: BoardIcon, label: '질문현황' },
+  // { href: '/status', Icon: BoardIcon, label: '질문현황' },
 ];
 
-type NavItmeProps = (typeof NAV_ITEMS)[number];
+type NavItemProps = (typeof NAV_ITEMS)[number];
 
-const NavItem = memo(({ href, Icon, label }: NavItmeProps) => {
+const NavItem = memo(({ href, Icon, label }: NavItemProps) => {
   const router = useRouter();
   const color = navIconColors[getNavItemStatus(router.pathname, href)];
 

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -31,7 +31,7 @@ export default function InviteStep() {
           //setOnboardingData(initialOnboardingState);
         },
         onError: (error) => {
-          console.log(error);
+          throw error;
         },
       }
     );

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -9,9 +9,16 @@ import {
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RecoilRoot } from 'recoil';
 import { NextPageWithLayout } from '@/types/page';
+import { ErrorBoundary } from 'react-error-boundary';
+import ErrorFallback from '@/components/error/ErrorFallback';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
+};
+
+type ErrorFallbackProp = {
+  resetErrorBoundary: (...args: any[]) => void;
 };
 
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
@@ -34,7 +41,18 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
     <RecoilRoot>
       <QueryClientProvider client={queryClient}>
         <HydrationBoundary state={pageProps.dehydratedState}>
-          {getLayout(<Component {...pageProps} />)}
+          <QueryErrorResetBoundary>
+            {({ reset }) => (
+              <ErrorBoundary
+                onReset={reset}
+                fallbackRender={({ resetErrorBoundary }: ErrorFallbackProp) => (
+                  <ErrorFallback resetErrorBoundary={resetErrorBoundary} />
+                )}
+              >
+                {getLayout(<Component {...pageProps} />)}
+              </ErrorBoundary>
+            )}
+          </QueryErrorResetBoundary>
         </HydrationBoundary>
         <ReactQueryDevtools />
       </QueryClientProvider>

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -7,8 +7,14 @@ import QuestionTitle from '@/components/answer/QuestionTitle';
 import useInput from '@/hooks/common/useInput';
 import usePostAnswer from '@/hooks/feature/usePostAnswer';
 import { useQueryClient } from '@tanstack/react-query';
+import axios from 'axios';
 
-const Page: NextPageWithLayout<{ id: string }> = ({ id: selectQuestionId }) => {
+type Prop = {
+  id: string;
+  question: string;
+};
+
+const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId, question }) => {
   const router = useRouter();
   const { mutate: postAnswer } = usePostAnswer();
 
@@ -29,7 +35,6 @@ const Page: NextPageWithLayout<{ id: string }> = ({ id: selectQuestionId }) => {
       { selectQuestionId: Number(selectQuestionId), answer },
       {
         onSuccess: () => {
-          //Todo: invalidateQueries
           queryClient.invalidateQueries({ queryKey: ['projects'] });
           router.push({
             pathname: '/chatroom',
@@ -45,7 +50,7 @@ const Page: NextPageWithLayout<{ id: string }> = ({ id: selectQuestionId }) => {
   };
   return (
     <section className="flex flex-col justify-between h-full">
-      <QuestionTitle question="당신이 좋아하는 계절은 언제인가요?" />
+      <QuestionTitle question={question} />
       <AnswerForm
         answer={answer}
         onChange={onChange}
@@ -67,6 +72,13 @@ Page.getLayout = function getLayout(page) {
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { id } = context.query;
 
+  const baseURL = process.env.NEXT_PUBLIC_BACKEND_GAMTI_URL;
+  const path = '/api/v1/answer';
+  const apiEndpoint = `${baseURL}${path}?selected-question-id=${id}`;
+
+  const res = await axios.get(apiEndpoint);
+  const question = res.data.question;
+
   const isValidId = (id: any) => {
     return !isNaN(Number(id));
   };
@@ -78,7 +90,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   }
 
   return {
-    props: { id },
+    props: { id, question },
   };
 }
 

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -42,8 +42,7 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId, question }) => {
           });
         },
         onError: (error) => {
-          //Todo: 에러 처리
-          console.log(error);
+          throw error;
         },
       }
     );

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -71,12 +71,20 @@ Page.getLayout = function getLayout(page) {
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { id } = context.query;
 
-  const baseURL = process.env.NEXT_PUBLIC_BACKEND_GAMTI_URL;
+  const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
   const path = '/api/v1/answer';
   const apiEndpoint = `${baseURL}${path}?selected-question-id=${id}`;
 
-  const res = await axios.get(apiEndpoint);
-  const question = res.data.question;
+  const getQuestion = async () => {
+    try {
+      const res = await axios.get(apiEndpoint);
+      return res.data.question;
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  const question = await getQuestion();
 
   const isValidId = (id: any) => {
     return !isNaN(Number(id));

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -40,7 +40,7 @@ type PageParam = {
 };
 
 const baseURL = process.env.NEXT_PUBLIC_BACKEND_GAMTI_URL;
-const path = '/api/v1/letters';
+const path = '/api/v1/letters1';
 const apiEndpoint = `${baseURL}${path}`;
 
 const getLetters = async ({ pageParam }: PageParam) => {
@@ -120,7 +120,7 @@ function useReversedInfiniteScroll(
 
 const Page: NextPageWithLayout<Letters> = () => {
   // useInfiniteQuery에서 fetchNextPage와 hasNextPage를 가져온다.
-  const { fetchNextPage, hasNextPage, data } = useInfiniteQuery({
+  const { fetchNextPage, hasNextPage, data, error } = useInfiniteQuery({
     queryKey: ['projects'],
     queryFn: getLetters,
     initialPageParam: 0,
@@ -155,6 +155,10 @@ const Page: NextPageWithLayout<Letters> = () => {
     bodyText: '',
     handleAction: () => {},
   });
+
+  if (error) {
+    throw error;
+  }
 
   const router = useRouter();
 

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -39,18 +39,20 @@ type PageParam = {
   pageParam: number;
 };
 
-const baseURL = process.env.NEXT_PUBLIC_BACKEND_GAMTI_URL;
-const path = '/api/v1/letters1';
+const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+const path = '/api/v1/letters';
 const apiEndpoint = `${baseURL}${path}`;
 
 const getLetters = async ({ pageParam }: PageParam) => {
   const url = pageParam
     ? `${apiEndpoint}?next-cursor=${pageParam}`
     : apiEndpoint;
-  const response = await axios.get(url);
-  // response.data.letters로 하면 nextCursor를 못받아와서 안됨
-  const letters = response.data;
-  return letters;
+  try {
+    const response = await axios.get(url);
+    return response.data;
+  } catch (error) {
+    throw error;
+  }
 };
 
 // useReversedInfiniteScroll라는 커스텀 훅

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -4,7 +4,7 @@ import MainLayout from '@/components/layout/MainLayout';
 import ListItem from '@/components/ui/ListItem';
 import { useRouter } from 'next/router';
 
-const baseURL = process.env.NEXT_PUBLIC_BACKEND_GAMTI_URL;
+const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
 const path = '/api/v1/questions';
 const apiEndpoint = `${baseURL}${path}`;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#61 #63 #64 

## 📝작업 내용
- 에러 페이지 추가 (#63)
- 답변 등록 페이지에 답변 api 연결 (#61)
- 네비게이션바 '질문 현황' 메뉴 제거 (#64)

### 에러 페이지
1. 404 페이지
    <img width="373" alt="스크린샷 2023-12-22 오후 9 26 00" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/70d9a380-d466-4e36-84e1-5fb8d14512e0">

2. 그 외 에러 페이지
  - 공통 에러 메시지 추가('에러가 발생했어요!')
  - 데이터를 다시 패칭하는 버튼 추가
    <img width="375" alt="스크린샷 2023-12-22 오후 9 28 06" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/ea8b3452-b376-4d45-9125-06d666a4846d">



### 스크린샷 (선택)

## 💬리뷰 요구사항
- 공통 에러 메시지('에러가 발생했어요') 대신 각 에러별로 더 상세한 에러 메시지를 넣을지 고민됩니다!