### PR TITLE
Feature/invitation page

### DIFF
--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -1,4 +1,5 @@
 export const LOCAL_STORAGE_KEYS = {
   PREV_URL: 'prevUrl',
   TOKEN: 'youare-iam-token',
+  TEXT_AREA_CONTENT: 'invite-page-answer',
 };

--- a/src/hooks/feature/usePostInviteAnswer.ts
+++ b/src/hooks/feature/usePostInviteAnswer.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+import { post } from '@/libs/api';
+
+type InviteAnswer = {
+  linkKey: string;
+  answer: string;
+};
+
+export const usePostAnswer = () => {
+  return useMutation({
+    mutationFn: (data: InviteAnswer) =>
+      post('/api/v1/members/invite/accept', data),
+  });
+};
+
+export default usePostAnswer;

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -7,7 +7,7 @@ import QuestionTitle from '@/components/answer/QuestionTitle';
 import useInput from '@/hooks/common/useInput';
 import usePostAnswer from '@/hooks/feature/usePostAnswer';
 import { useQueryClient } from '@tanstack/react-query';
-import axios from 'axios';
+import { get } from '@/libs/api';
 
 type Prop = {
   id: string;
@@ -71,13 +71,9 @@ Page.getLayout = function getLayout(page) {
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   const { id } = context.query;
 
-  const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
-  const path = '/api/v1/answer';
-  const apiEndpoint = `${baseURL}${path}?selected-question-id=${id}`;
-
   const getQuestion = async () => {
     try {
-      const res = await axios.get(apiEndpoint);
+      const res = await get(`/api/v1/answer?selected-question-id=${id}`);
       return res.data.question;
     } catch (error) {
       throw error;

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -4,9 +4,8 @@ import Modal from '@/components/ui/Modal';
 import QuestionBar from '@/components/ui/QuestionBar';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useState, useEffect, useRef } from 'react';
-import axios from 'axios';
 import { useRouter } from 'next/router';
-import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
+import { get } from '@/libs/api';
 
 type Letters = {
   letters: LetterType[];
@@ -48,13 +47,9 @@ const getLetters = async ({ pageParam }: PageParam) => {
   const url = pageParam
     ? `${apiEndpoint}?next-cursor=${pageParam}`
     : apiEndpoint;
-  console.log('url: ', url);
+
   try {
-    const response = await axios.get(url, {
-      headers: {
-        Authorization: localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN),
-      },
-    });
+    const response = await get(url);
     return response.data;
   } catch (error) {
     throw error;

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -6,6 +6,7 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useState, useEffect, useRef } from 'react';
 import axios from 'axios';
 import { useRouter } from 'next/router';
+import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 
 type Letters = {
   letters: LetterType[];
@@ -47,8 +48,13 @@ const getLetters = async ({ pageParam }: PageParam) => {
   const url = pageParam
     ? `${apiEndpoint}?next-cursor=${pageParam}`
     : apiEndpoint;
+  console.log('url: ', url);
   try {
-    const response = await axios.get(url);
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN),
+      },
+    });
     return response.data;
   } catch (error) {
     throw error;

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -11,10 +11,6 @@ import { useRouter } from 'next/router';
 import type { GetServerSidePropsContext } from 'next';
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 
-const config = {
-  linkKey: process.env.NEXT_PUBLIC_LINK_KEY,
-};
-
 type Data = {
   data: {
     question: string;
@@ -123,7 +119,7 @@ export const getServerSideProps = async (
   context: GetServerSidePropsContext
 ) => {
   console.log('context:  ', context);
-  const id = Object.keys(context.query).toString();
+  const { id } = context.query;
   console.log('id:  ', id);
   const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
   const path = '/api/v1/members/invite/info/';

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -5,24 +5,37 @@ import ListItem from '@/components/ui/ListItem';
 import TextArea from '@/components/ui/TextArea';
 import Button from '@/components/ui/Button';
 import axios from 'axios';
+import { get } from 'http';
+import { useEffect } from 'react';
 
 const question = '같이 해보고 싶은 버킷리스트가 있나요?';
 
-const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
-const path = '/api/v1/members/invite/info';
-const apiEndpoint = `${baseURL}${path}`;
-
-const getInviteInfo = async () => {
-  const response = await axios.get(apiEndpoint);
-  return response?.data.invitedPersonName;
+const config = {
+  linkKey: process.env.NEXT_PUBLIC_LINK_KEY,
 };
 
-const Page: NextPageWithLayout = () => {
-  const invitedPerson = getInviteInfo();
+const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+const path = '/api/v1/members/invite/info/';
+const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
+
+// const getInviteInfo = async () => {
+//   const response = await axios.get(apiEndpoint, {
+//     params: {
+//       linkKey: config.linkKey,
+//     },
+//   });
+//   console.log(response.data.invitedPersonName);
+//   console.log(typeof response.data.invitedPersonName);
+//   return response.data.invitedPersonName;
+
+// return response.data;
+// };
+
+const Page: NextPageWithLayout = ({ invitedName }) => {
   return (
     <>
       <div className="mt-10">
-        <div>{invitedPerson}이</div>
+        <div>{invitedName}이</div>
         <div>초대 링크를 보냈어요!</div>
       </div>
       <ListItem
@@ -54,6 +67,22 @@ Page.getLayout = function getLayout(page) {
   return (
     <BasicLayout className="bg-[#F7CBC3] justify-center">{page}</BasicLayout>
   );
+};
+
+export const getStaticProps = async () => {
+  try {
+    const response = await axios.get(apiEndpoint, {
+      params: {
+        linkKey: config.linkKey,
+      },
+    });
+
+    const invitedName = response.data.invitedPersonName;
+    return { props: { invitedName } };
+  } catch (error) {
+    console.error('Error fetching data:', (error as Error).message);
+    return { props: { invitedName: [] } };
+  }
 };
 
 export default Page;

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -41,10 +41,11 @@ const Page: NextPageWithLayout<Data> = ({ data }) => {
       const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
       const path = '/api/v1/members/invite/accept';
       const apiEndpoint = `${baseURL}${path}`;
+      const accessToken = localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN);
+      // console.log(accessToken);
       axios
         .post(
           apiEndpoint,
-
           {
             linkKey: config.linkKey,
             // linkKey: params?.id,
@@ -52,12 +53,12 @@ const Page: NextPageWithLayout<Data> = ({ data }) => {
           },
           {
             headers: {
-              Authorization: localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN),
+              Authorization: accessToken,
             },
           }
         )
         .then(function (response) {
-          console.log(response);
+          console.log(response.data.selectedQuestionId);
           router.push('/chatroom');
         });
     }

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -7,6 +7,8 @@ import Button from '@/components/ui/Button';
 import axios from 'axios';
 import { get } from 'http';
 import { useEffect } from 'react';
+import Link from 'next/link';
+import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
 
 const question = '같이 해보고 싶은 버킷리스트가 있나요?';
 
@@ -18,15 +20,19 @@ const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
 const path = '/api/v1/members/invite/info/';
 const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
 
-type InvitedName = {
-  invitedName: string;
+type Data = {
+  data: {
+    question: string;
+    invitedPersonName: string;
+  };
 };
 
-const Page: NextPageWithLayout<InvitedName> = ({ invitedName }) => {
+const Page: NextPageWithLayout<Data> = ({ data }) => {
+  console.log(data);
   return (
     <>
       <div className="mt-10 flex flex-col items-center">
-        <div>{invitedName} 님이</div>
+        <div>{data.invitedPersonName} 님이</div>
         <div>초대 링크를 보냈어요!</div>
       </div>
       <ListItem
@@ -68,8 +74,8 @@ export const getStaticProps = async () => {
       },
     });
 
-    const invitedName = response.data.invitedPersonName;
-    return { props: { invitedName } };
+    const data = response.data;
+    return { props: { data } };
   } catch (error) {
     console.error('Error fetching data:', (error as Error).message);
     return { props: { invitedName: [] } };

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -6,7 +6,6 @@ import TextArea from '@/components/ui/TextArea';
 import Button from '@/components/ui/Button';
 import axios from 'axios';
 import { useState, useEffect } from 'react';
-import Link from 'next/link';
 import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
 import { useRouter } from 'next/router';
 import { GetStaticPropsContext } from 'next';
@@ -32,7 +31,36 @@ const Page: NextPageWithLayout<Data> = ({ data }) => {
   };
 
   const handleSubmitAnswer = () => {
+    // {KAKAO_AUTH_URL}
+    const isLogin = window.localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN);
     window.localStorage.setItem(LOCAL_STORAGE_KEYS.TEXT_AREA_CONTENT, text);
+    if (!isLogin) {
+      window.location.href = KAKAO_AUTH_URL;
+    } else {
+      // post 요청 보내고 chatroom으로 이동
+      const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+      const path = '/api/v1/members/invite/accept';
+      const apiEndpoint = `${baseURL}${path}`;
+      axios
+        .post(
+          apiEndpoint,
+
+          {
+            linkKey: config.linkKey,
+            // linkKey: params?.id,
+            answer: text,
+          },
+          {
+            headers: {
+              Authorization: localStorage.getItem(LOCAL_STORAGE_KEYS.TOKEN),
+            },
+          }
+        )
+        .then(function (response) {
+          console.log(response);
+          router.push('/chatroom');
+        });
+    }
   };
 
   useEffect(() => {
@@ -74,15 +102,14 @@ const Page: NextPageWithLayout<Data> = ({ data }) => {
         onChange={handleChangeText}
         className="min-h-[15rem]"
       />
-      <Link
-        href={KAKAO_AUTH_URL}
-        className="w-full"
+      <Button
         onClick={handleSubmitAnswer}
+        variant="primary"
+        size="wide"
+        className="mt-5"
       >
-        <Button variant="primary" size="wide" className="mt-5">
-          답변 등록
-        </Button>
-      </Link>
+        답변 등록
+      </Button>
     </>
   );
 };

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -18,24 +18,15 @@ const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
 const path = '/api/v1/members/invite/info/';
 const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
 
-// const getInviteInfo = async () => {
-//   const response = await axios.get(apiEndpoint, {
-//     params: {
-//       linkKey: config.linkKey,
-//     },
-//   });
-//   console.log(response.data.invitedPersonName);
-//   console.log(typeof response.data.invitedPersonName);
-//   return response.data.invitedPersonName;
+type InvitedName = {
+  invitedName: string;
+};
 
-// return response.data;
-// };
-
-const Page: NextPageWithLayout = ({ invitedName }) => {
+const Page: NextPageWithLayout<InvitedName> = ({ invitedName }) => {
   return (
     <>
-      <div className="mt-10">
-        <div>{invitedName}이</div>
+      <div className="mt-10 flex flex-col items-center">
+        <div>{invitedName} 님이</div>
         <div>초대 링크를 보냈어요!</div>
       </div>
       <ListItem

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -9,16 +9,14 @@ import { get } from 'http';
 import { useEffect } from 'react';
 import Link from 'next/link';
 import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
+import { useRouter } from 'next/router';
+import { GetStaticPropsContext } from 'next';
 
 const question = '같이 해보고 싶은 버킷리스트가 있나요?';
 
 const config = {
   linkKey: process.env.NEXT_PUBLIC_LINK_KEY,
 };
-
-const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
-const path = '/api/v1/members/invite/info/';
-const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
 
 type Data = {
   data: {
@@ -28,7 +26,8 @@ type Data = {
 };
 
 const Page: NextPageWithLayout<Data> = ({ data }) => {
-  console.log(data);
+  const router = useRouter();
+  console.log(router.pathname);
   return (
     <>
       <div className="mt-10 flex flex-col items-center">
@@ -66,11 +65,18 @@ Page.getLayout = function getLayout(page) {
   );
 };
 
-export const getStaticProps = async () => {
+export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
+  const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+  const path = '/api/v1/members/invite/info/';
+  // const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
+  const apiEndpoint = `${baseURL}${path}${params?.id}`;
+
+  console.log(params?.id);
   try {
     const response = await axios.get(apiEndpoint, {
       params: {
-        linkKey: config.linkKey,
+        // linkKey: config.linkKey,
+        linkKey: params?.id,
       },
     });
 

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -20,6 +20,7 @@ type Data = {
     question: string;
     invitedPersonName: string;
   };
+  id: string;
 };
 
 const Page: NextPageWithLayout<Data> = ({ data, id }) => {

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -5,39 +5,24 @@ import ListItem from '@/components/ui/ListItem';
 import TextArea from '@/components/ui/TextArea';
 import Button from '@/components/ui/Button';
 import axios from 'axios';
-import { get } from 'http';
-import { useEffect } from 'react';
-import Link from 'next/link';
-import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
-import { useRouter } from 'next/router';
-import { GetStaticPropsContext } from 'next';
-import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 
 const question = '같이 해보고 싶은 버킷리스트가 있나요?';
 
-const config = {
-  linkKey: process.env.NEXT_PUBLIC_LINK_KEY,
+const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
+const path = '/api/v1/members/invite/info';
+const apiEndpoint = `${baseURL}${path}`;
+
+type InviteInfo = {
+  selectedQuestionId: number;
+  invitedPersonName: string;
 };
 
-type Data = {
-  data: {
-    question: string;
-    invitedPersonName: string;
-  };
-};
-
-const Page: NextPageWithLayout<Data> = ({ data }) => {
-  const router = useRouter();
-  console.log(router.pathname);
-
-  useEffect(() => {
-    window.localStorage.setItem(LOCAL_STORAGE_KEYS.PREV_URL, router.asPath);
-  }, []);
-
+const Page: NextPageWithLayout<InviteInfo> = ({ inviteInfo }) => {
+  console.log('inviteInfo: ', inviteInfo);
   return (
     <>
-      <div className="mt-10 flex flex-col items-center">
-        <div>{data?.invitedPersonName} 님이</div>
+      <div className="mt-10">
+        <div>{inviteInfo?.invitedPersonName}이</div>
         <div>초대 링크를 보냈어요!</div>
       </div>
       <ListItem
@@ -71,26 +56,15 @@ Page.getLayout = function getLayout(page) {
   );
 };
 
-export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
-  const path = '/api/v1/members/invite/info/';
-  const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
-  // const apiEndpoint = `${baseURL}${path}${params?.id}`;
-
-  console.log(params?.id);
+export const getStaticProps = async () => {
   try {
-    const response = await axios.get(apiEndpoint, {
-      params: {
-        linkKey: config.linkKey,
-        // linkKey: params?.id,
-      },
-    });
-
-    const data = response.data;
-    return { props: { data } };
+    const response = await axios.get(apiEndpoint);
+    const inviteInfo = response.data;
+    console.log('inviteInfo: ', inviteInfo);
+    return { props: { inviteInfo } };
   } catch (error) {
     console.error('Error fetching data:', (error as Error).message);
-    return { props: { invitedName: [] } };
+    return { props: { inviteInfo: [] } };
   }
 };
 

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
 import { useRouter } from 'next/router';
 import { GetStaticPropsContext } from 'next';
+import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 
 const question = '같이 해보고 싶은 버킷리스트가 있나요?';
 
@@ -28,10 +29,15 @@ type Data = {
 const Page: NextPageWithLayout<Data> = ({ data }) => {
   const router = useRouter();
   console.log(router.pathname);
+
+  useEffect(() => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEYS.PREV_URL, router.asPath);
+  }, []);
+
   return (
     <>
       <div className="mt-10 flex flex-col items-center">
-        <div>{data.invitedPersonName} 님이</div>
+        <div>{data?.invitedPersonName} 님이</div>
         <div>초대 링크를 보냈어요!</div>
       </div>
       <ListItem
@@ -68,15 +74,15 @@ Page.getLayout = function getLayout(page) {
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
   const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
   const path = '/api/v1/members/invite/info/';
-  // const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
-  const apiEndpoint = `${baseURL}${path}${params?.id}`;
+  const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
+  // const apiEndpoint = `${baseURL}${path}${params?.id}`;
 
   console.log(params?.id);
   try {
     const response = await axios.get(apiEndpoint, {
       params: {
-        // linkKey: config.linkKey,
-        linkKey: params?.id,
+        linkKey: config.linkKey,
+        // linkKey: params?.id,
       },
     });
 

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -12,17 +12,17 @@ const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
 const path = '/api/v1/members/invite/info';
 const apiEndpoint = `${baseURL}${path}`;
 
-type InviteInfo = {
-  selectedQuestionId: number;
-  invitedPersonName: string;
+const getInviteInfo = async () => {
+  const response = await axios.get(apiEndpoint);
+  return response?.data.invitedPersonName;
 };
 
-const Page: NextPageWithLayout<InviteInfo> = ({ inviteInfo }) => {
-  console.log('inviteInfo: ', inviteInfo);
+const Page: NextPageWithLayout = () => {
+  const invitedPerson = getInviteInfo();
   return (
     <>
       <div className="mt-10">
-        <div>{inviteInfo?.invitedPersonName}이</div>
+        <div>{invitedPerson}이</div>
         <div>초대 링크를 보냈어요!</div>
       </div>
       <ListItem
@@ -54,18 +54,6 @@ Page.getLayout = function getLayout(page) {
   return (
     <BasicLayout className="bg-[#F7CBC3] justify-center">{page}</BasicLayout>
   );
-};
-
-export const getStaticProps = async () => {
-  try {
-    const response = await axios.get(apiEndpoint);
-    const inviteInfo = response.data;
-    console.log('inviteInfo: ', inviteInfo);
-    return { props: { inviteInfo } };
-  } catch (error) {
-    console.error('Error fetching data:', (error as Error).message);
-    return { props: { inviteInfo: [] } };
-  }
 };
 
 export default Page;

--- a/src/pages/invite/index.tsx
+++ b/src/pages/invite/index.tsx
@@ -5,15 +5,12 @@ import ListItem from '@/components/ui/ListItem';
 import TextArea from '@/components/ui/TextArea';
 import Button from '@/components/ui/Button';
 import axios from 'axios';
-import { get } from 'http';
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
 import { useRouter } from 'next/router';
 import { GetStaticPropsContext } from 'next';
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
-
-const question = '같이 해보고 싶은 버킷리스트가 있나요?';
 
 const config = {
   linkKey: process.env.NEXT_PUBLIC_LINK_KEY,
@@ -27,12 +24,29 @@ type Data = {
 };
 
 const Page: NextPageWithLayout<Data> = ({ data }) => {
+  const [text, setText] = useState('');
   const router = useRouter();
-  console.log(router.pathname);
+
+  const handleChangeText = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setText(e.target.value);
+  };
+
+  const handleSubmitAnswer = () => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEYS.TEXT_AREA_CONTENT, text);
+  };
+
+  useEffect(() => {
+    const storedText = window.localStorage.getItem(
+      LOCAL_STORAGE_KEYS.TEXT_AREA_CONTENT
+    );
+    if (storedText) {
+      setText(storedText);
+    }
+  }, []);
 
   useEffect(() => {
     window.localStorage.setItem(LOCAL_STORAGE_KEYS.PREV_URL, router.asPath);
-  }, []);
+  }, [router.asPath]);
 
   return (
     <>
@@ -55,8 +69,16 @@ const Page: NextPageWithLayout<Data> = ({ data }) => {
       <div className="mb-5">
         <div>답변을 작성해 볼까요?</div>
       </div>
-      <TextArea value="" onChange={() => {}} className="min-h-[15rem]" />
-      <Link href={KAKAO_AUTH_URL} className="w-full">
+      <TextArea
+        value={text}
+        onChange={handleChangeText}
+        className="min-h-[15rem]"
+      />
+      <Link
+        href={KAKAO_AUTH_URL}
+        className="w-full"
+        onClick={handleSubmitAnswer}
+      >
         <Button variant="primary" size="wide" className="mt-5">
           답변 등록
         </Button>
@@ -77,7 +99,6 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
   const apiEndpoint = `${baseURL}${path}${config.linkKey}`;
   // const apiEndpoint = `${baseURL}${path}${params?.id}`;
 
-  console.log(params?.id);
   try {
     const response = await axios.get(apiEndpoint, {
       params: {

--- a/src/pages/login/kakao/index.tsx
+++ b/src/pages/login/kakao/index.tsx
@@ -21,7 +21,12 @@ export default function Login() {
         );
 
         const prevUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.PREV_URL);
-        router.push(prevUrl || '/onboarding');
+        if (prevUrl === '/invite') {
+          router.push('/chatroom');
+        } else {
+          router.push(prevUrl || '/onboarding');
+        }
+        // router.push(prevUrl || '/onboarding');
         localStorage.removeItem(LOCAL_STORAGE_KEYS.PREV_URL);
       } catch (err) {
         setError('로그인 중 오류가 발생했습니다. 다시 시도해주세요.');

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -1,12 +1,8 @@
-import axios from 'axios';
 import type { NextPageWithLayout } from '@/types/page';
 import MainLayout from '@/components/layout/MainLayout';
 import ListItem from '@/components/ui/ListItem';
 import { useRouter } from 'next/router';
-
-const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
-const path = '/api/v1/questions';
-const apiEndpoint = `${baseURL}${path}`;
+import { get, post } from '@/libs/api';
 
 type Questions = {
   questions: Question[];
@@ -21,28 +17,13 @@ const Page: NextPageWithLayout<Questions> = ({ questions }) => {
   const router = useRouter();
 
   const handleItemClick = async (questionId: Question['questionId']) => {
-    // console.log(questionId);
     try {
-      // POST 요청으로 questionId를 보내기
-      const postResponse = await axios.post(apiEndpoint, {
+      await post('/api/v1/questions', {
         questionId: questionId,
       });
-
-      // 응답으로 받은 selectedQuestionId를 가져오기
-      const selectedQuestionId = postResponse.data.selectedQuestionId;
-      // console.log(selectedQuestionId);
-
-      const targetPath = '/chatroom';
-      // selectedQuestionId가 있는 위치로 이동하기
-      // 위치 만들기
-      router.push({
-        pathname: targetPath,
-        // 답변 수정, 답변 등록 페이지에는 selectQuestionId가 들어가야 함.
-        // 질문 선택 페이지에는 마지막 selectQuestionsId가 들어가야 함.
-        // hash: '0',
-      });
+      router.push('/chatroom');
     } catch (error) {
-      console.error('Error fetching data:', (error as Error).message);
+      throw error;
     }
   };
 
@@ -67,14 +48,14 @@ Page.getLayout = function getLayout(page) {
   return <MainLayout>{page}</MainLayout>;
 };
 
-export const getStaticProps = async () => {
+export const getServerSideProps = async () => {
   try {
-    const response = await axios.get(apiEndpoint);
+    const response = await get('/api/v1/questions');
     const questions = response.data;
     console.log('questions', questions);
     return { props: { questions } };
   } catch (error) {
-    console.error('Error fetching data:', (error as Error).message);
+    console.error('Error fetching data questions:', (error as Error).message);
     return { props: { questions: [] } };
   }
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#41 

## 📝작업 내용

초대링크로 접속할 시 랜딩되는 페이지를 작업하였습니다.

### 흐름
1. url에 포함된 linkKey를 사용하여 GET 요청을 보내 question과 invitedPersonName를 화면에 렌더링합니다.
2. 답변 작성 후 답변 등록 버튼 클릭 시 카카오 로그인 페이지로 이동하고, 로그인 완료 후 다시 초대링크 랜딩 페이지로 돌아옵니다. 
3. 로그인 전에 작성했던 답변은 로컬 스토리지에 저장하여 로그인 후에도 작성한 답변이 남아있습니다.
4. 로그인 이후 다시 답변 등록 버튼을 클릭하면 최종적으로 답변이 등록되고, 대화 상세 페이지로 이동합니다. 
