### PR TITLE
fix: 데이터 변경시 chatroom, questions 리렌더링 되도록 수정

### DIFF
--- a/src/components/ui/QuestionBar.tsx
+++ b/src/components/ui/QuestionBar.tsx
@@ -24,8 +24,6 @@ type letterProps = {
 };
 
 const QuestionBar = ({ onClick, letter }: letterProps) => {
-  // console.log('questionBar letter', letter);
-  // console.log('letter.answerCount', letter.answerCount);
   if (letter.answerCount === 0) {
     return (
       <div

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -36,7 +36,7 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
       { selectQuestionId: Number(selectQuestionId), answer },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ['projects'] });
+          queryClient.invalidateQueries({ queryKey: ['letters'] });
           router.push({
             pathname: '/chatroom',
             hash: selectQuestionId,

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -71,7 +71,7 @@ const Page: NextPageWithLayout<Letters> = () => {
 
   // useInfiniteQuery에서 fetchNextPage와 hasNextPage를 가져온다.
   const { fetchNextPage, hasNextPage, data, error } = useInfiniteQuery({
-    queryKey: ['projects'],
+    queryKey: ['letters'],
     queryFn: getLetters,
     initialPageParam: 0,
 
@@ -136,8 +136,6 @@ const Page: NextPageWithLayout<Letters> = () => {
       setIsModalOpen(true);
     }
   };
-
-  // queryClient.invalidateQueries({ queryKey: ['projects'] });
 
   return (
     <div className="pb-[5rem]">

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -44,7 +44,7 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
         { linkKey: id, answer: text },
         {
           onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['projects'] });
+            queryClient.invalidateQueries({ queryKey: ['letters'] });
             router.push('/chatroom');
           },
           onError: (error) => {

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -6,7 +6,7 @@ import { post } from '@/libs/api';
 import useQuestionList, {
   getQuestionList,
 } from '@/hooks/queries/useQuestionList';
-import { QueryClient, dehydrate } from '@tanstack/react-query';
+import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 
 type Questions = {
   questions: Question[];
@@ -19,6 +19,7 @@ type Question = {
 
 const Page: NextPageWithLayout<Questions> = ({ questions }) => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { questionList } = useQuestionList();
 
   const handleItemClick = async (questionId: Question['questionId']) => {
@@ -26,6 +27,8 @@ const Page: NextPageWithLayout<Questions> = ({ questions }) => {
       await post('/api/v1/questions', {
         questionId: questionId,
       });
+      queryClient.invalidateQueries({ queryKey: ['question-list'] });
+      queryClient.invalidateQueries({ queryKey: ['letters'] });
       router.push('/chatroom');
     } catch (error) {
       throw error;


### PR DESCRIPTION
## #️⃣연관된 이슈

#73 

## 📝작업 내용

questions 페이지에서 질문을 선택했을 때 화면에서 바로 사라지지 않고, chatroom 페이지에서도 질문이 바로 추가되지 않는 오류가 있었습니다.

questions 페이지에서 질문을 선택하면 선택한 질문이 사라지고 chatroom에서 바로 선택된 질문이 추가되도록 수정하였습니다.

questions 페이지에 아래 코드를 추가하여 해결하였습니다.

```tsx
queryClient.invalidateQueries({ queryKey: ['question-list'] });
queryClient.invalidateQueries({ queryKey: ['letters'] });
```

### 기타
chatroom에 있던 기존의 코드 `queryClient.invalidateQueries({ queryKey: ['letters'] });`로 인해 리렌더링이 무한루프에 빠지는 오류도 있었습니다. 이는 useEffect 안에 넣어서 처리하거나, 현재 방식처럼 onSuccess 안에 넣어서 처리하면 되는 오류였습니다.
