### PR TITLE
Feature/auth routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "framer-motion": "^10.16.16",
         "js-cookie": "^3.0.5",
         "next": "14.0.3",
+        "nookies": "^2.5.2",
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.12",
@@ -1190,6 +1191,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3260,6 +3269,15 @@
       "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
       "dev": true
     },
+    "node_modules/nookies": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/nookies/-/nookies-2.5.2.tgz",
+      "integrity": "sha512-x0TRSaosAEonNKyCrShoUaJ5rrT5KHRNZ5DwPCuizjgrnkpE5DRf3VL7AyyQin4htict92X1EQ7ejDbaHDVdYA==",
+      "dependencies": {
+        "cookie": "^0.4.1",
+        "set-cookie-parser": "^2.4.6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4024,6 +4042,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.6.0.tgz",
+      "integrity": "sha512-RVnVQxTXuerk653XfuliOxBP81Sf0+qfQE73LIYKcyMYHG94AuH0kgrQpRDuTZnSmjpysHmzxJXKNfa6PjFhyQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "framer-motion": "^10.16.16",
     "js-cookie": "^3.0.5",
     "next": "14.0.3",
+    "nookies": "^2.5.2",
     "react": "^18",
     "react-dom": "^18",
     "react-error-boundary": "^4.0.12",

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -10,6 +10,10 @@ import { useRouter } from 'next/router';
 import { m } from 'framer-motion';
 
 const TEMPLATE_ID = 102113;
+const domain =
+  process.env.NODE_ENV === 'production'
+    ? 'https://youare-iam.vercel.app'
+    : 'http://localhost:3000';
 
 export default function InviteStep() {
   const router = useRouter();
@@ -32,6 +36,7 @@ export default function InviteStep() {
               question: onboardingData.selectedQuestion.question,
               invitedPersonName: data.invitedPersonName,
               linkKey: data.linkKey,
+              domain,
             },
           });
           // TODO: redirect to chatroom

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -28,8 +28,6 @@ export default function InviteStep() {
       },
       {
         onSuccess: ({ data }) => {
-          console.log(data);
-
           window.Kakao.Share.sendCustom({
             templateId: TEMPLATE_ID,
             templateArgs: {
@@ -41,7 +39,7 @@ export default function InviteStep() {
           });
           // TODO: redirect to chatroom
           // router.push('/chatroom');
-          // setOnboardingData(initialOnboardingState);
+          setOnboardingData(initialOnboardingState);
         },
         onError: (error) => {
           throw error;

--- a/src/hooks/auth/useAuth.ts
+++ b/src/hooks/auth/useAuth.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
+import { authState } from '@/store/auth';
+import { getAccessToken } from '@/libs/token';
+
+const useAuth = () => {
+  const [isAuthenticated, setIsAuthenticated] = useRecoilState(authState);
+
+  useEffect(() => {
+    const token = getAccessToken();
+
+    if (token) {
+      setIsAuthenticated(true);
+    }
+  }, [setIsAuthenticated]);
+
+  return { isAuthenticated, setIsAuthenticated };
+};
+
+export default useAuth;

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -9,6 +9,8 @@ import usePostAnswer from '@/hooks/queries/usePostAnswer';
 import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import useQuestion, { getQuestion } from '@/hooks/queries/useQuestion';
 
+import { checkAuth } from '@/util/checkAuth';
+
 type Prop = {
   id: string;
   question: string;
@@ -71,15 +73,21 @@ Page.getLayout = function getLayout(page) {
 };
 
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const { id } = context.query;
+  const authCheck = await checkAuth(context);
+  if (authCheck) {
+    return authCheck;
+  }
 
+  const { id } = context.query;
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery({
     queryKey: ['question', id],
     queryFn: () => getQuestion(Number(id)),
+    //add error handling
   });
 
+  // Todo: api 응답이 404일 경우에 notfound 페이지를 보여주도록 수정
   const isValidId = (id: any) => {
     return !isNaN(Number(id));
   };

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -1,14 +1,16 @@
+import { GetServerSidePropsContext } from 'next';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { useSetRecoilState } from 'recoil';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import type { NextPageWithLayout } from '@/types/page';
 import MainLayout from '@/components/layout/MainLayout';
 import Modal from '@/components/ui/Modal';
 import QuestionBar from '@/components/ui/QuestionBar';
-import { useInfiniteQuery } from '@tanstack/react-query';
-import { useState } from 'react';
-import { useRouter } from 'next/router';
 import { get } from '@/libs/api';
-import useReversedInfiniteScroll from '@/hooks/common/useReversedInfiniteScroll';
-import { useSetRecoilState } from 'recoil';
 import { myIdState } from '@/store/myIdState';
+import { checkAuth } from '@/util/checkAuth';
+import useReversedInfiniteScroll from '@/hooks/common/useReversedInfiniteScroll';
 
 type Letters = {
   letters: LetterType[];
@@ -178,4 +180,12 @@ Page.getLayout = function getLayout(page) {
   return <MainLayout>{page}</MainLayout>;
 };
 
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const authCheck = await checkAuth(context);
+  if (authCheck) {
+    return authCheck;
+  }
+
+  return { props: {} };
+}
 export default Page;

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -4,7 +4,6 @@ import type { NextPageWithLayout } from '@/types/page';
 import ListItem from '@/components/ui/ListItem';
 import TextArea from '@/components/ui/TextArea';
 import Button from '@/components/ui/Button';
-import axios from 'axios';
 import { useState, useEffect } from 'react';
 import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
 import { useRouter } from 'next/router';
@@ -13,7 +12,7 @@ import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { useQueryClient } from '@tanstack/react-query';
 import { get } from '@/libs/api';
-import { getAccessToken } from '@/libs/token';
+import useAuth from '@/hooks/auth/useAuth';
 
 type Data = {
   data: {
@@ -28,16 +27,16 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
   const router = useRouter();
   const { mutate: postInviteAnswer } = usePostInviteAnswer();
   const queryClient = useQueryClient();
+  const { isAuthenticated } = useAuth();
 
   const handleChangeText = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(e.target.value);
   };
 
   const handleSubmitAnswer = () => {
-    const isLogin = getAccessToken();
     window.localStorage.setItem(LOCAL_STORAGE_KEYS.TEXT_AREA_CONTENT, text);
 
-    if (!isLogin) {
+    if (!isAuthenticated) {
       window.location.href = KAKAO_AUTH_URL;
     } else {
       postInviteAnswer(

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -38,12 +38,16 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
 
     if (!isAuthenticated) {
       window.location.href = KAKAO_AUTH_URL;
+      window.localStorage.setItem(LOCAL_STORAGE_KEYS.PREV_URL, router.asPath);
     } else {
       postInviteAnswer(
         { linkKey: id, answer: text },
         {
           onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['letters'] });
+            window.localStorage.removeItem(
+              LOCAL_STORAGE_KEYS.TEXT_AREA_CONTENT
+            );
             router.push('/chatroom');
           },
           onError: (error) => {
@@ -62,10 +66,6 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
       setText(storedText);
     }
   }, []);
-
-  useEffect(() => {
-    window.localStorage.setItem(LOCAL_STORAGE_KEYS.PREV_URL, router.asPath);
-  }, [router.asPath]);
 
   return (
     <>

--- a/src/pages/login/kakao/index.tsx
+++ b/src/pages/login/kakao/index.tsx
@@ -22,11 +22,7 @@ export default function Login() {
         setAuthHeader(instance, accessToken);
 
         const prevUrl = localStorage.getItem(LOCAL_STORAGE_KEYS.PREV_URL);
-        if (prevUrl === '/invite') {
-          router.push('/chatroom');
-        } else {
-          router.push(prevUrl || '/onboarding');
-        }
+        router.push(prevUrl || '/chatroom');
         localStorage.removeItem(LOCAL_STORAGE_KEYS.PREV_URL);
       } catch (err) {
         setError('로그인 중 오류가 발생했습니다. 다시 시도해주세요.');

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -57,7 +57,7 @@ Page.getLayout = function getLayout(page) {
 
 export default Page;
 
-export const getStaticProps = async () => {
+export async function getServerSideProps() {
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery({
@@ -70,4 +70,4 @@ export const getStaticProps = async () => {
       initialState: dehydrate(queryClient),
     },
   };
-};
+}

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -7,6 +7,8 @@ import useQuestionList, {
   getQuestionList,
 } from '@/hooks/queries/useQuestionList';
 import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
+import { checkAuth } from '@/util/checkAuth';
+import { GetServerSidePropsContext } from 'next';
 
 type Questions = {
   questions: Question[];
@@ -56,7 +58,12 @@ Page.getLayout = function getLayout(page) {
   return <MainLayout>{page}</MainLayout>;
 };
 
-export async function getServerSideProps() {
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const authCheck = await checkAuth(context);
+  if (authCheck) {
+    return authCheck;
+  }
+
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery({

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -40,7 +40,7 @@ const Page: NextPageWithLayout<Questions> = ({ questions }) => {
       {questionList.map((question) => (
         <div
           key={question.questionId}
-          className="flex flex-col justify-center items-center"
+          className="flex flex-col items-center justify-center"
         >
           <ListItem
             question={question.question}
@@ -56,7 +56,7 @@ Page.getLayout = function getLayout(page) {
   return <MainLayout>{page}</MainLayout>;
 };
 
-export const getStaticProps = async () => {
+export async function getServerSideProps() {
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery({
@@ -68,6 +68,6 @@ export const getStaticProps = async () => {
       initialState: dehydrate(queryClient),
     },
   };
-};
+}
 
 export default Page;

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const authState = atom({
+  key: 'authState',
+  default: false,
+});

--- a/src/util/checkAuth.ts
+++ b/src/util/checkAuth.ts
@@ -1,0 +1,19 @@
+import { ACCESS_TOKEN } from '@/constants/auth';
+import { GetServerSidePropsContext } from 'next';
+import { parseCookies } from 'nookies';
+
+export async function checkAuth(context: GetServerSidePropsContext) {
+  const cookies = parseCookies(context);
+  const accessToken = cookies[ACCESS_TOKEN];
+
+  if (!accessToken) {
+    return {
+      redirect: {
+        destination: '/',
+        permanent: false,
+      },
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #54

## 📝작업 내용
1. checkAuth 구현 : 
-  인증이 필요한 페이지 ( /chatroom, /questions, /answer )의 경우 쿠키에 액세스 토큰이 저장되어 있는 경우에만 해당 페이지에 접근할 수 있도록 구현 

2. authState 전역상태, useAuth 훅
- 클라이언트 사이드에서 로그인 상태를 사용할 경우에 사용할 수 있도록,  액세스 토큰이 쿠키에 저장되어 있는지 여부로 로그인 상태를 확인할 수 있는 훅을 구현

3. invite 페이지 관련 라우팅 수정 
- 로그인 성공 →/invite페이지 → 커플 수락 성공 이후 → /chatroom페이지
