### PR TITLE
Feature/error UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-error-boundary": "^4.0.12",
+        "react-hot-toast": "^2.4.1",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -1239,8 +1240,7 @@
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
-      "dev": true
+      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/culori": {
       "version": "3.3.0",
@@ -2348,6 +2348,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.14",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.14.tgz",
+      "integrity": "sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/gopd": {
@@ -3815,6 +3823,21 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.4.1.tgz",
+      "integrity": "sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==",
+      "dependencies": {
+        "goober": "^2.1.10"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-error-boundary": "^4.0.12",
+    "react-hot-toast": "^2.4.1",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -19,7 +19,7 @@ const domain =
 export default function InviteStep() {
   const router = useRouter();
   const [onboardingData, setOnboardingData] = useRecoilState(onboardingState);
-  const { mutate: createInviteKey } = useCreateInviteKey();
+  const { mutate: createInviteKey, isPending } = useCreateInviteKey();
 
   const handleInvite = () => {
     createInviteKey(
@@ -80,7 +80,12 @@ export default function InviteStep() {
           </div>
         </m.article>
       </section>
-      <Button variant="primary" size="wide" onClick={handleInvite}>
+      <Button
+        variant="primary"
+        size="wide"
+        onClick={handleInvite}
+        isLoading={isPending}
+      >
         초대링크 전송하기
       </Button>
     </>

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -1,4 +1,7 @@
+import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
+import { m } from 'framer-motion';
+import toast from 'react-hot-toast';
 import Button from '@/components/ui/Button';
 import {
   initialOnboardingState,
@@ -6,8 +9,6 @@ import {
 } from '@/store/onboardingState';
 import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import LockIcon from '../icons/LockIcon';
-import { useRouter } from 'next/router';
-import { m } from 'framer-motion';
 import type { ErrorResponse } from '@/types/api';
 
 const TEMPLATE_ID = 102113;
@@ -46,7 +47,7 @@ export default function InviteStep() {
         },
         onError: (error: unknown) => {
           const errorResponse = error as ErrorResponse;
-          alert(errorResponse.message);
+          toast.error(errorResponse.message);
         },
       }
     );

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -8,8 +8,7 @@ import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import LockIcon from '../icons/LockIcon';
 import { useRouter } from 'next/router';
 import { m } from 'framer-motion';
-import { AxiosError } from 'axios';
-import { ErrorResponse } from '@/libs/api';
+import type { ErrorResponse } from '@/types/api';
 
 const TEMPLATE_ID = 102113;
 const domain =
@@ -30,6 +29,8 @@ export default function InviteStep() {
       },
       {
         onSuccess: ({ data }) => {
+          //Todo: 카카오 공유하기 try catch로 감싸기
+          console.log(data);
           window.Kakao.Share.sendCustom({
             templateId: TEMPLATE_ID,
             templateArgs: {

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/store/onboardingState';
 import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import LockIcon from '../icons/LockIcon';
-import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 const TEMPLATE_ID = 102113;
 const domain =
@@ -44,7 +43,6 @@ export default function InviteStep() {
           // router.push('/chatroom');
           // setOnboardingData(initialOnboardingState);
         },
-        onError: showToastErrorMessage,
       }
     );
   };

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
 import { m } from 'framer-motion';
-import toast from 'react-hot-toast';
 import Button from '@/components/ui/Button';
 import {
   initialOnboardingState,
@@ -9,7 +8,7 @@ import {
 } from '@/store/onboardingState';
 import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import LockIcon from '../icons/LockIcon';
-import type { ErrorResponse } from '@/types/api';
+import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 const TEMPLATE_ID = 102113;
 const domain =
@@ -45,10 +44,7 @@ export default function InviteStep() {
           // router.push('/chatroom');
           // setOnboardingData(initialOnboardingState);
         },
-        onError: (error: unknown) => {
-          const errorResponse = error as ErrorResponse;
-          toast.error(errorResponse.message);
-        },
+        onError: showToastErrorMessage,
       }
     );
   };

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -8,6 +8,8 @@ import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import LockIcon from '../icons/LockIcon';
 import { useRouter } from 'next/router';
 import { m } from 'framer-motion';
+import { AxiosError } from 'axios';
+import { ErrorResponse } from '@/libs/api';
 
 const TEMPLATE_ID = 102113;
 const domain =
@@ -39,10 +41,11 @@ export default function InviteStep() {
           });
           // TODO: redirect to chatroom
           // router.push('/chatroom');
-          setOnboardingData(initialOnboardingState);
+          // setOnboardingData(initialOnboardingState);
         },
-        onError: (error) => {
-          throw error;
+        onError: (error: unknown) => {
+          const errorResponse = error as ErrorResponse;
+          alert(errorResponse.message);
         },
       }
     );

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -5,6 +5,7 @@ import axios, {
   AxiosError,
 } from 'axios';
 import { getAccessToken, removeAccessToken } from './token';
+import { ErrorResponse } from '@/types/api';
 
 export const instance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
@@ -36,7 +37,7 @@ const interceptorResponseFulfilled = (res: AxiosResponse) => {
 const interceptorResponseRejected = (error: AxiosError) => {
   if (error.response?.status === 401) {
     removeAccessToken();
-    window.location.href = '/';
+    // window.location.href = '/';
     return Promise.reject(error.response.data as ErrorResponse);
   }
   return Promise.reject(error.response?.data as ErrorResponse);
@@ -60,8 +61,3 @@ export const post = <T = any, D = any, R = AxiosResponse<T>>(
 ) => {
   return instance.post<T, R>(url, data);
 };
-
-export interface ErrorResponse {
-  code: number;
-  message: string;
-}

--- a/src/libs/api.ts
+++ b/src/libs/api.ts
@@ -37,9 +37,9 @@ const interceptorResponseRejected = (error: AxiosError) => {
   if (error.response?.status === 401) {
     removeAccessToken();
     window.location.href = '/';
-    return Promise.reject(error.response.data);
+    return Promise.reject(error.response.data as ErrorResponse);
   }
-  return Promise.reject(error.response?.data);
+  return Promise.reject(error.response?.data as ErrorResponse);
 };
 
 instance.interceptors.response.use(
@@ -60,3 +60,8 @@ export const post = <T = any, D = any, R = AxiosResponse<T>>(
 ) => {
   return instance.post<T, R>(url, data);
 };
+
+export interface ErrorResponse {
+  code: number;
+  message: string;
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,6 +14,7 @@ import { ErrorBoundary } from 'react-error-boundary';
 import ErrorFallback from '@/components/error/ErrorFallback';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
+import { Toaster } from 'react-hot-toast';
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
@@ -59,6 +60,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
       ></Script>
       <RecoilRoot>
         <QueryClientProvider client={queryClient}>
+          <Toaster />
           <HydrationBoundary state={pageProps.dehydratedState}>
             <LazyMotion features={domAnimation}>
               <QueryErrorResetBoundary>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import ErrorFallback from '@/components/error/ErrorFallback';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { LazyMotion, domAnimation } from 'framer-motion';
 import { Toaster } from 'react-hot-toast';
+import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
@@ -41,6 +42,9 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
             retry: false,
             refetchOnWindowFocus: false,
             staleTime: 60 * 1000,
+          },
+          mutations: {
+            onError: showToastErrorMessage,
           },
         },
       })

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -1,6 +1,5 @@
 import type { GetServerSidePropsContext } from 'next';
 import { useRouter } from 'next/router';
-import toast from 'react-hot-toast';
 
 import type { NextPageWithLayout } from '@/types/page';
 import PageLayoutWithTitle from '@/components/layout/PageLayoutWithTitle';
@@ -11,7 +10,7 @@ import usePostAnswer from '@/hooks/queries/usePostAnswer';
 import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import useQuestion, { getQuestion } from '@/hooks/queries/useQuestion';
 import { checkAuth } from '@/util/checkAuth';
-import { ErrorResponse } from '@/types/api';
+import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 type Prop = {
   id: string;
@@ -46,10 +45,7 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
             hash: selectQuestionId,
           });
         },
-        onError: (error: unknown) => {
-          const errorResponse = error as ErrorResponse;
-          toast.error(errorResponse.message);
-        },
+        onError: showToastErrorMessage,
       }
     );
   };

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -10,7 +10,6 @@ import usePostAnswer from '@/hooks/queries/usePostAnswer';
 import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import useQuestion, { getQuestion } from '@/hooks/queries/useQuestion';
 import { checkAuth } from '@/util/checkAuth';
-import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 type Prop = {
   id: string;
@@ -45,7 +44,6 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
             hash: selectQuestionId,
           });
         },
-        onError: showToastErrorMessage,
       }
     );
   };

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -19,7 +19,7 @@ type Prop = {
 
 const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
   const router = useRouter();
-  const { mutate: postAnswer } = usePostAnswer();
+  const { mutate: postAnswer, isPending } = usePostAnswer();
 
   const [answer, onChange, errorMessage] = useInput('', (value) =>
     value.trim() ? '' : '답변을 입력해주세요'
@@ -58,6 +58,7 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
         onChange={onChange}
         errorMessage={errorMessage}
         handleSubmit={handleSubmit}
+        isLoading={isPending}
       />
     </section>
   );

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -1,5 +1,7 @@
 import type { GetServerSidePropsContext } from 'next';
 import { useRouter } from 'next/router';
+import toast from 'react-hot-toast';
+
 import type { NextPageWithLayout } from '@/types/page';
 import PageLayoutWithTitle from '@/components/layout/PageLayoutWithTitle';
 import AnswerForm from '@/components/answer/AnswerForm';
@@ -8,8 +10,8 @@ import useInput from '@/hooks/common/useInput';
 import usePostAnswer from '@/hooks/queries/usePostAnswer';
 import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import useQuestion, { getQuestion } from '@/hooks/queries/useQuestion';
-
 import { checkAuth } from '@/util/checkAuth';
+import { ErrorResponse } from '@/types/api';
 
 type Prop = {
   id: string;
@@ -44,8 +46,9 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
             hash: selectQuestionId,
           });
         },
-        onError: (error) => {
-          throw error;
+        onError: (error: unknown) => {
+          const errorResponse = error as ErrorResponse;
+          toast.error(errorResponse.message);
         },
       }
     );

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -14,7 +14,6 @@ import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { get } from '@/libs/api';
 import useAuth from '@/hooks/auth/useAuth';
-import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 type Data = {
   data: {
@@ -52,7 +51,6 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
             );
             router.push('/chatroom');
           },
-          onError: showToastErrorMessage,
         }
       );
     }

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -1,16 +1,18 @@
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/router';
 import Image from 'next/image';
+import type { GetServerSidePropsContext } from 'next';
+import { useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+
 import BasicLayout from '@/components/layout/BasicLayout';
 import type { NextPageWithLayout } from '@/types/page';
 import ListItem from '@/components/ui/ListItem';
 import TextArea from '@/components/ui/TextArea';
 import Button from '@/components/ui/Button';
-import { useState, useEffect } from 'react';
 import { KAKAO_AUTH_URL } from '@/constants/kakaoAuth';
-import { useRouter } from 'next/router';
-import type { GetServerSidePropsContext } from 'next';
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
-import { useQueryClient } from '@tanstack/react-query';
 import { get } from '@/libs/api';
 import useAuth from '@/hooks/auth/useAuth';
 import type { ErrorResponse } from '@/types/api';
@@ -53,7 +55,7 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
           },
           onError: (error: unknown) => {
             const errorResponse = error as ErrorResponse;
-            alert(errorResponse.message);
+            toast.error(errorResponse.message);
           },
         }
       );

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -11,7 +11,7 @@ import type { GetServerSidePropsContext } from 'next';
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { useQueryClient } from '@tanstack/react-query';
-import { get } from '@/libs/api';
+import { ErrorResponse, get } from '@/libs/api';
 import useAuth from '@/hooks/auth/useAuth';
 
 type Data = {
@@ -50,8 +50,9 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
             );
             router.push('/chatroom');
           },
-          onError: (error) => {
-            throw error;
+          onError: (error: unknown) => {
+            const errorResponse = error as ErrorResponse;
+            alert(errorResponse.message);
           },
         }
       );

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -11,8 +11,9 @@ import type { GetServerSidePropsContext } from 'next';
 import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { useQueryClient } from '@tanstack/react-query';
-import { ErrorResponse, get } from '@/libs/api';
+import { get } from '@/libs/api';
 import useAuth from '@/hooks/auth/useAuth';
+import type { ErrorResponse } from '@/types/api';
 
 type Data = {
   data: {

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import Image from 'next/image';
 import type { GetServerSidePropsContext } from 'next';
 import { useQueryClient } from '@tanstack/react-query';
-import toast from 'react-hot-toast';
 
 import BasicLayout from '@/components/layout/BasicLayout';
 import type { NextPageWithLayout } from '@/types/page';
@@ -15,7 +14,7 @@ import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { get } from '@/libs/api';
 import useAuth from '@/hooks/auth/useAuth';
-import type { ErrorResponse } from '@/types/api';
+import { showToastErrorMessage } from '@/util/showToastErrorMessage';
 
 type Data = {
   data: {
@@ -53,10 +52,7 @@ const Page: NextPageWithLayout<Data> = ({ data, id }) => {
             );
             router.push('/chatroom');
           },
-          onError: (error: unknown) => {
-            const errorResponse = error as ErrorResponse;
-            toast.error(errorResponse.message);
-          },
+          onError: showToastErrorMessage,
         }
       );
     }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,3 +1,9 @@
+export interface ErrorResponse {
+  code: string;
+  status: number;
+  message: string;
+}
+
 export type Question = {
   questionId: number;
   question: string;

--- a/src/util/showToastErrorMessage.ts
+++ b/src/util/showToastErrorMessage.ts
@@ -1,0 +1,7 @@
+import toast from 'react-hot-toast';
+import type { ErrorResponse } from '@/types/api';
+
+export const showToastErrorMessage = (error: unknown) => {
+  const errorResponse = error as ErrorResponse;
+  toast.error(errorResponse.message);
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #78 

## 📝작업 내용

> 서버 에러 메시지를 보여주는 ui를 추가했습니다. 

![Kapture 2024-01-22 at 13 21 18](https://github.com/coding-union-kr/youare-iam-fe/assets/96093996/9c6644b1-069e-4d34-bc93-2e0787b44ea9)

- 서버의 변경된 에러 타입을  `src/types/api.ts`에 추가했습니다. 
```ts
export interface ErrorResponse {
  code: string;
  status: number;
  message: string;
}
```
-  에러가 발생하면 toast 메시지를 보여주는 `showToastErrorMessage`를 구현했고, `_app.tsx`의 queryClient에 연결해서 mutation에서 발생한 에러 처리를 전역으로 처리하도록 구현했습니다. 

```ts
  const [queryClient] = useState(
    () =>
      new QueryClient({
        defaultOptions: {
          queries: {
            retry: false,
            refetchOnWindowFocus: false,
            staleTime: 60 * 1000,
          },
          mutations: {
            onError: showToastErrorMessage,
          },
        },
      })
  );

```