### PR TITLE
Feature/error already selected question

### DIFF
--- a/src/components/ui/ChatBubble.tsx
+++ b/src/components/ui/ChatBubble.tsx
@@ -17,12 +17,12 @@ const ChatBubble = ({ answer }: ChatBubbleProps) => {
   return (
     <>
       <div className="chat chat-start">
-        <div className="chat-bubble bg-[#ffffff]">{otherAnswer.answer}</div>
-        <div className="chat-footer opacity-50">{otherAnswer.createdAt}</div>
+        <div className="chat-bubble bg-[#ffffff]">{otherAnswer?.answer}</div>
+        <div className="chat-footer opacity-50">{otherAnswer?.createdAt}</div>
       </div>
       <div className="chat chat-end">
-        <div className="chat-bubble bg-[#FEB2B2]">{myAnswer.answer}</div>
-        <div className="chat-footer opacity-50">{myAnswer.createdAt}</div>
+        <div className="chat-bubble bg-[#FEB2B2]">{myAnswer?.answer}</div>
+        <div className="chat-footer opacity-50">{myAnswer?.createdAt}</div>
       </div>
     </>
   );

--- a/src/hooks/queries/usePostQuestion.ts
+++ b/src/hooks/queries/usePostQuestion.ts
@@ -1,0 +1,14 @@
+import { useMutation } from '@tanstack/react-query';
+import { post } from '@/libs/api';
+
+type Question = {
+  questionId: number;
+};
+
+export const usePostQuestion = () => {
+  return useMutation({
+    mutationFn: (data: Question) => post('/api/v1/questions', data),
+  });
+};
+
+export default usePostQuestion;

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -33,16 +33,6 @@ const Page: NextPageWithLayout<Questions> = () => {
         onSuccess: () => {
           router.push('/chatroom');
         },
-        // onError: (error) => {
-        //   // TODO: 에러 처리
-        //   const e = error as unknown as ErrorResponse;
-        //   if (e.status === 409) {
-        //     if (e.code === 'Q003') {
-        //       queryClient.invalidateQueries({ queryKey: ['question-list'] });
-        //       queryClient.invalidateQueries({ queryKey: ['letters'] });
-        //     }
-        //   }
-        // },
       }
     );
   };

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -9,6 +9,7 @@ import useQuestionList, {
 import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import { checkAuth } from '@/util/checkAuth';
 import { GetServerSidePropsContext } from 'next';
+import type { ErrorResponse } from '@/types/api';
 
 type Questions = {
   questions: Question[];
@@ -33,7 +34,12 @@ const Page: NextPageWithLayout<Questions> = ({ questions }) => {
       queryClient.invalidateQueries({ queryKey: ['letters'] });
       router.push('/chatroom');
     } catch (error) {
-      throw error;
+      const e = error as ErrorResponse;
+      if (e.status === 409) {
+        if (e.code === 'Q003') {
+          alert('이미 선택된 질문입니다.');
+        }
+      }
     }
   };
 

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -10,37 +10,41 @@ import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import { checkAuth } from '@/util/checkAuth';
 import { GetServerSidePropsContext } from 'next';
 import type { ErrorResponse } from '@/types/api';
+import type { Question } from '@/types/api';
+import usePostQuestion from '@/hooks/queries/usePostQuestion';
 
 type Questions = {
   questions: Question[];
 };
 
-type Question = {
-  questionId: number;
-  question: string;
-};
-
-const Page: NextPageWithLayout<Questions> = ({ questions }) => {
+const Page: NextPageWithLayout<Questions> = () => {
   const router = useRouter();
   const queryClient = useQueryClient();
   const { questionList } = useQuestionList();
-
+  const { mutate: postQuestion } = usePostQuestion();
   const handleItemClick = async (questionId: Question['questionId']) => {
-    try {
-      await post('/api/v1/questions', {
-        questionId: questionId,
-      });
-      queryClient.invalidateQueries({ queryKey: ['question-list'] });
-      queryClient.invalidateQueries({ queryKey: ['letters'] });
-      router.push('/chatroom');
-    } catch (error) {
-      const e = error as ErrorResponse;
-      if (e.status === 409) {
-        if (e.code === 'Q003') {
-          alert('이미 선택된 질문입니다.');
-        }
+    postQuestion(
+      { questionId: questionId },
+      {
+        onSettled: () => {
+          queryClient.invalidateQueries({ queryKey: ['question-list'] });
+          queryClient.invalidateQueries({ queryKey: ['letters'] });
+        },
+        onSuccess: () => {
+          router.push('/chatroom');
+        },
+        // onError: (error) => {
+        //   // TODO: 에러 처리
+        //   const e = error as unknown as ErrorResponse;
+        //   if (e.status === 409) {
+        //     if (e.code === 'Q003') {
+        //       queryClient.invalidateQueries({ queryKey: ['question-list'] });
+        //       queryClient.invalidateQueries({ queryKey: ['letters'] });
+        //     }
+        //   }
+        // },
       }
-    }
+    );
   };
 
   return (


### PR DESCRIPTION
## #️⃣연관된 이슈

#87 

## 📝작업 내용
- 질문 선택 요청을 react-query의 mutation을 사용하도록 수정하여 에러 발생시에 showToastErrorMessage가 실행되도록 작업하였습니다.

  ```tsx
  mutations: {
    onError: showToastErrorMessage,
  },
  ```

- 이미 선택된 질문 클릭시 에러메시지가 담긴 Toast가 나타난 후 해당 질문이 질문 목록에서 삭제됩니다. 

  <img src='https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/b762d506-f0fa-47f1-864f-c0426a1763bf' width='30%'>

- 질문 선택시 기본적으로 invalidateQueries가 실행되도록 하고, 성공 시에만 대화 상세 페이지로 이동됩니다.

  ```tsx
  postQuestion(
      { questionId: questionId },
      {
        onSettled: () => {
          queryClient.invalidateQueries({ queryKey: ['question-list'] });
          queryClient.invalidateQueries({ queryKey: ['letters'] });
        },
        onSuccess: () => {
          router.push('/chatroom');
        },
      }
    );
  ```

