### PR TITLE
feat: production 환경에서의 카카오로그인 redirect 주소 추가

### DIFF
--- a/src/constants/kakaoAuth.ts
+++ b/src/constants/kakaoAuth.ts
@@ -1,4 +1,7 @@
 const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID; // 카카오 개발자 콘솔에서 발급받은 REST API 키
-const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI; // 카카오로부터 인증 응답을 받을 서버의 URI
+const redirectUri =
+  process.env.NODE_ENV === 'production'
+    ? 'https://youare-iam.vercel.app/login/kakao'
+    : process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI; // 카카오로부터 인증 응답을 받을 서버의 URI
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 

## 📝작업 내용
 - [x] production 환경에서의 redirect 주소를 현재 프론트엔드 배포 주소로 설정

배포 환경에서 로그인이 되지 않는 문제를 해결하기 위해서 아래의 코드를 추가했습니다. 
```ts
const redirectUri =
  process.env.NODE_ENV === 'production'
    ? 'https://youare-iam.vercel.app/login/kakao'
    : process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI; // 카카오로부터 인증 응답을 받을 서버의 URI
```