### PR TITLE
Feature/routing based on user status

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,13 +1,23 @@
+import Button from '@/components/ui/Button';
+import Link from 'next/link';
+
 const Custom404 = () => {
   return (
     <section>
-      <div className="h-screen flex flex-col items-center pt-20">
-        <div className="font-neo text-4xl mb-4 text-primary">
-          404 Page Not Found
+      <div className="h-screen flex flex-col items-center py-20 justify-between">
+        <div>
+          <div className="font-neo text-4xl mb-4 text-primary">
+            404 Page Not Found
+          </div>
+          <div className="font-neo text-lg mb-4">
+            원하시는 페이지를 찾을 수 없습니다.
+          </div>
         </div>
-        <div className="font-neo text-lg mb-4">
-          원하시는 페이지를 찾을 수 없습니다.
-        </div>
+        <Link href="/" className="w-full flex items-center justify-center">
+          <Button variant="primary" size="wide">
+            홈으로 돌아가기
+          </Button>
+        </Link>
       </div>
     </section>
   );

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -12,6 +12,7 @@ import useQuestion from '@/hooks/queries/useQuestion';
 import { checkAuth } from '@/util/checkAuth';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import { Question } from '@/types/api';
+import { userStatusRouting } from '@/util/userStatusRouting';
 
 type Prop = {
   id: string;
@@ -104,6 +105,12 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     return {
       notFound: true,
     };
+  }
+
+  const redirection = await userStatusRouting(context);
+
+  if (redirection) {
+    return redirection;
   }
 
   return {

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -12,7 +12,7 @@ import useQuestion from '@/hooks/queries/useQuestion';
 import { checkAuth } from '@/util/checkAuth';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import { Question } from '@/types/api';
-import { userStatusRouting } from '@/util/userStatusRouting';
+import { disallowAccess } from '@/util/disallowAccess';
 
 type Prop = {
   id: string;
@@ -107,7 +107,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     };
   }
 
-  const redirection = await userStatusRouting(context);
+  const redirection = await disallowAccess(context);
 
   if (redirection) {
     return redirection;

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -15,7 +15,7 @@ import axios from 'axios';
 import { parseCookies } from 'nookies';
 import { ACCESS_TOKEN } from '@/constants/auth';
 import { setAuthHeader } from '@/libs/token';
-import { userStatusRouting } from '@/util/userStatusRouting';
+import { disallowAccess } from '@/util/disallowAccess';
 
 type Letter = {
   selectQuestionId: number;
@@ -209,7 +209,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const accessToken = cookies[ACCESS_TOKEN];
   setAuthHeader(instance, accessToken);
 
-  const redirection = await userStatusRouting(context);
+  const redirection = await disallowAccess(context);
 
   if (redirection) {
     return redirection;

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -11,14 +11,14 @@ import { get } from '@/libs/clientSideApi';
 import { myIdState } from '@/store/myIdState';
 import { checkAuth } from '@/util/checkAuth';
 import useReversedInfiniteScroll from '@/hooks/queries/useReversedInfiniteScroll';
+import axios from 'axios';
+// type Data = {
+//   letters: Letter[];
+//   nextCursor: number;
+//   myId: string;
+// };
 
-type Letters = {
-  letters: LetterType[];
-  nextCursor: number;
-  myId: string;
-};
-
-type LetterType = {
+type Letter = {
   selectQuestionId: number;
   question: string;
   createdAt: string;
@@ -34,6 +34,11 @@ type LetterType = {
     | null;
 };
 
+type UserStatus = {
+  userStatus: string;
+  linkKey: string;
+};
+
 type ModalInfo = {
   actionText: string;
   cancelText: string;
@@ -45,7 +50,10 @@ type PageParam = {
   pageParam: number;
 };
 
-const Page: NextPageWithLayout<Letters> = () => {
+const Page: NextPageWithLayout<UserStatus> = ({ userStatus, linkKey }) => {
+  console.log('userStatus: ', userStatus);
+  console.log('linkKey: ', linkKey);
+
   const setMyId = useSetRecoilState(myIdState);
   const getLetters = async ({ pageParam }: PageParam) => {
     const baseURL = process.env.NEXT_PUBLIC_BACKEND_URL;
@@ -103,7 +111,7 @@ const Page: NextPageWithLayout<Letters> = () => {
     hasNextPage,
     data?.length ?? 0 // 훅에서 dataLength가 됨
   );
-  const handleQuestionBarClick = ({ letter }: { letter: LetterType }) => {
+  const handleQuestionBarClick = ({ letter }: { letter: Letter }) => {
     if (letter.answerCount === 0) {
       setModalInfo({
         actionText: '답변 작성하러 가기',
@@ -162,7 +170,7 @@ const Page: NextPageWithLayout<Letters> = () => {
         // 스크롤이 움직이면 실행되는 handleScroll이라는 이벤트핸들러가 실행된다.
         onScroll={handleScroll}
       >
-        {data?.map((letter: LetterType, index: number) => {
+        {data?.map((letter: Letter, index: number) => {
           return (
             <QuestionBar
               key={index}
@@ -186,6 +194,15 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     return authCheck;
   }
 
-  return { props: {} };
+  const res = await get(
+    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/v1/members/user-status`
+  );
+
+  const { userStatus, linkKey } = res.data;
+
+  console.log('userStatus: ', userStatus);
+  console.log('linkKey: ', linkKey);
+
+  return { props: { userStatus, linkKey } };
 }
 export default Page;

--- a/src/pages/chatroom/index.tsx
+++ b/src/pages/chatroom/index.tsx
@@ -15,12 +15,7 @@ import axios from 'axios';
 import { parseCookies } from 'nookies';
 import { ACCESS_TOKEN } from '@/constants/auth';
 import { setAuthHeader } from '@/libs/token';
-
-// type Data = {
-//   letters: Letter[];
-//   nextCursor: number;
-//   myId: string;
-// };
+import { userStatusRouting } from '@/util/userStatusRouting';
 
 type Letter = {
   selectQuestionId: number;
@@ -214,9 +209,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const accessToken = cookies[ACCESS_TOKEN];
   setAuthHeader(instance, accessToken);
 
+  const redirection = await userStatusRouting(context);
+
+  if (redirection) {
+    return redirection;
+  }
+
   try {
     const res = await instance.get(`/api/v1/members/user-status`);
-
     if (res.data.userStatus === 'NON_COUPLE_USER') {
       return {
         redirect: {
@@ -225,7 +225,6 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
         },
       };
     }
-
     return { props: { userData: res.data } };
   } catch (error) {
     console.error('Error fetching data:', (error as Error).message);

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router';
 import Image from 'next/image';
 import type { GetServerSidePropsContext } from 'next';
 import { useQueryClient } from '@tanstack/react-query';
-
 import BasicLayout from '@/components/layout/BasicLayout';
 import type { NextPageWithLayout } from '@/types/page';
 import ListItem from '@/components/ui/ListItem';
@@ -14,6 +13,7 @@ import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { get } from '@/libs/clientSideApi';
 import useAuth from '@/hooks/auth/useAuth';
+import { userStatusRouting } from '@/util/userStatusRouting';
 
 type Data = {
   data: {
@@ -113,6 +113,12 @@ export const getServerSideProps = async (
   context: GetServerSidePropsContext
 ) => {
   const { id } = context.query;
+
+  const redirection = await userStatusRouting(context);
+
+  if (redirection) {
+    return redirection;
+  }
 
   try {
     const response = await get(`/api/v1/members/invite/info/${id}`);

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -15,7 +15,7 @@ import { get } from '@/libs/clientSideApi';
 import useAuth from '@/hooks/auth/useAuth';
 import { disallowAccess } from '@/util/disallowAccess';
 
-type Data = {
+type InviteData = {
   data: {
     question: string;
     invitedPersonName: string;
@@ -23,7 +23,7 @@ type Data = {
   id: string;
 };
 
-const Page: NextPageWithLayout<Data> = ({ data, id }) => {
+const Page: NextPageWithLayout<InviteData> = ({ data, id }) => {
   const [text, setText] = useState('');
   const router = useRouter();
   const { mutate: postInviteAnswer } = usePostInviteAnswer();

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -13,7 +13,7 @@ import { LOCAL_STORAGE_KEYS } from '@/constants/localStorageKeys';
 import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { get } from '@/libs/clientSideApi';
 import useAuth from '@/hooks/auth/useAuth';
-import { userStatusRouting } from '@/util/userStatusRouting';
+import { disallowAccess } from '@/util/disallowAccess';
 
 type Data = {
   data: {
@@ -114,7 +114,7 @@ export const getServerSideProps = async (
 ) => {
   const { id } = context.query;
 
-  const redirection = await userStatusRouting(context);
+  const redirection = await disallowAccess(context);
 
   if (redirection) {
     return redirection;

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -10,7 +10,7 @@ import InviteStep from '@/components/onboarding/InviteStep';
 import useQuestionList from '@/hooks/queries/useQuestionList';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import type { Question } from '@/types/api';
-import { userStatusRouting } from '@/util/userStatusRouting';
+import { disallowAccess } from '@/util/disallowAccess';
 
 const onboardingSteps = ['questions', 'answer', 'invite'] as const;
 
@@ -69,7 +69,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     queryFn: () => fetchData<Question[]>(api, '/questions'),
   });
 
-  const redirection = await userStatusRouting(context);
+  const redirection = await disallowAccess(context);
 
   if (redirection) {
     return redirection;

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -10,6 +10,7 @@ import InviteStep from '@/components/onboarding/InviteStep';
 import useQuestionList from '@/hooks/queries/useQuestionList';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import type { Question } from '@/types/api';
+import { userStatusRouting } from '@/util/userStatusRouting';
 
 const onboardingSteps = ['questions', 'answer', 'invite'] as const;
 
@@ -67,6 +68,12 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     queryKey: ['question-list'],
     queryFn: () => fetchData<Question[]>(api, '/questions'),
   });
+
+  const redirection = await userStatusRouting(context);
+
+  if (redirection) {
+    return redirection;
+  }
 
   return {
     props: {

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -9,6 +9,7 @@ import useQuestionList from '@/hooks/queries/useQuestionList';
 import { checkAuth } from '@/util/checkAuth';
 import usePostQuestion from '@/hooks/queries/usePostQuestion';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
+import { userStatusRouting } from '@/util/userStatusRouting';
 
 type Questions = {
   questions: Question[];
@@ -69,6 +70,13 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     queryKey: ['question-list'],
     queryFn: () => fetchData<Question[]>(api, '/questions'),
   });
+
+  const redirection = await userStatusRouting(context);
+
+  if (redirection) {
+    return redirection;
+  }
+
   return {
     props: {
       initialState: dehydrate(queryClient),

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -9,7 +9,7 @@ import useQuestionList from '@/hooks/queries/useQuestionList';
 import { checkAuth } from '@/util/checkAuth';
 import usePostQuestion from '@/hooks/queries/usePostQuestion';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
-import { userStatusRouting } from '@/util/userStatusRouting';
+import { disallowAccess } from '@/util/disallowAccess';
 
 type Questions = {
   questions: Question[];
@@ -71,7 +71,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     queryFn: () => fetchData<Question[]>(api, '/questions'),
   });
 
-  const redirection = await userStatusRouting(context);
+  const redirection = await disallowAccess(context);
 
   if (redirection) {
     return redirection;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -8,3 +8,13 @@ export type Question = {
   questionId: number;
   question: string;
 };
+
+export type UserStatus =
+  | 'COUPLE_USER'
+  | 'COUPLE_WAITING_USER'
+  | 'NON_COUPLE_USER';
+
+export type UserData = {
+  userStatus: UserStatus;
+  linkKey: string;
+};

--- a/src/util/disallowAccess.ts
+++ b/src/util/disallowAccess.ts
@@ -6,7 +6,7 @@ import { GetServerSidePropsContext } from 'next';
 
 type UserStatus = 'COUPLE_USER' | 'COUPLE_WAITING_USER' | 'NON_COUPLE_USER';
 
-export const userStatusRouting = async (context: GetServerSidePropsContext) => {
+export const disallowAccess = async (context: GetServerSidePropsContext) => {
   const instance = axios.create({
     baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
     timeout: 15000,
@@ -34,7 +34,7 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
       pathPatterns.questions,
       pathPatterns.answer,
     ],
-    NON_COUPLE_USER: [pathPatterns.questions, pathPatterns.answer], // checkAuth 때문에 동작하지 않음
+    NON_COUPLE_USER: [pathPatterns.questions, pathPatterns.answer],
   };
 
   const userStatus = res.data.userStatus as UserStatus;

--- a/src/util/userStatusRouting.ts
+++ b/src/util/userStatusRouting.ts
@@ -4,9 +4,7 @@ import { ACCESS_TOKEN } from '@/constants/auth';
 import { setAuthHeader } from '@/libs/token';
 import { GetServerSidePropsContext } from 'next';
 
-type DisallowMap = {
-  [key: string]: RegExp[];
-};
+type UserStatus = 'COUPLE_USER' | 'COUPLE_WAITING_USER' | 'NON_COUPLE_USER';
 
 export const userStatusRouting = async (context: GetServerSidePropsContext) => {
   const instance = axios.create({
@@ -21,23 +19,26 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
   const res = await instance.get(`/api/v1/members/user-status`);
 
   const path = context.resolvedUrl;
-  const disallowMap: DisallowMap = {
-    COUPLE_USER: [
-      /\/onboarding/,
-      /\/invite\/[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}/,
-    ],
-    COUPLE_WAITING_USER: [
-      /\/onboarding/,
-      /\/invite\/[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}/,
-      /\/answer\/\d*/,
-    ],
-    NON_COUPLE_USER: [/\/answer\/\d*/, /\/questions/], // checkAuth 때문에 동작하지 않음
+
+  const pathPatterns = {
+    onboarding: /^\/onboarding$/,
+    invite: /^\/invite\/[\da-z]{8}(-[\da-z]{4}){3}-[0-9a-z]{12}$/,
+    answer: /^\/answer\/\d*$/,
+    questions: /^\/questions$/,
   };
 
-  if (
-    disallowMap[res.data.userStatus]?.some((regex: RegExp) => regex.test(path))
-  ) {
-    console.log('리다이렉트5');
+  const disallowedPaths: Record<UserStatus, RegExp[]> = {
+    COUPLE_USER: [pathPatterns.onboarding, pathPatterns.invite],
+    COUPLE_WAITING_USER: [
+      pathPatterns.onboarding,
+      pathPatterns.questions,
+      pathPatterns.answer,
+    ],
+    NON_COUPLE_USER: [pathPatterns.questions, pathPatterns.answer], // checkAuth 때문에 동작하지 않음
+  };
+
+  const userStatus = res.data.userStatus as UserStatus;
+  if (disallowedPaths[userStatus]?.some((pattern) => pattern.test(path))) {
     return {
       redirect: {
         permanent: false,

--- a/src/util/userStatusRouting.ts
+++ b/src/util/userStatusRouting.ts
@@ -16,15 +16,18 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
 
   const res = await instance.get(`/api/v1/members/user-status`);
 
-  // TODO: /invite/[id], /answer/[id] 정규표현식 처리하기
-  const unauthorizedPagesForCoupleUser = ['/onboarding', '/invite'];
+  const inviteRegex =
+    /^\/invite\/[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/;
+  const answerRegex = /^\/answer\/\d*$/;
+
+  const unauthorizedPagesForCoupleUser = ['/onboarding', '/invite/[id]'];
   const unauthorizedPagesForCoupleWaitingUser = [
     '/onboarding',
-    '/invite',
-    '/answer',
+    '/invite/[id]',
+    '/answer/[id]',
   ];
   const unauthorizedPagesForNonCoupleUser = [
-    '/answer',
+    '/answer/[id]',
     '/questions',
     // '/chatroom', -> chatroom에 들어가면 onboarding으로 리다이렉트되기 때문에 넣으면 안됨
   ];
@@ -33,7 +36,10 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
 
   switch (res.data.userStatus) {
     case 'COUPLE_USER':
-      if (unauthorizedPagesForCoupleUser.includes(path)) {
+      if (
+        unauthorizedPagesForCoupleUser.includes(path) ||
+        inviteRegex.test(path)
+      ) {
         return {
           redirect: {
             permanent: false,
@@ -43,7 +49,11 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
       }
       break;
     case 'COUPLE_WAITING_USER':
-      if (unauthorizedPagesForCoupleWaitingUser.includes(path)) {
+      if (
+        unauthorizedPagesForCoupleWaitingUser.includes(path) ||
+        inviteRegex.test(path) ||
+        answerRegex.test(path)
+      ) {
         return {
           redirect: {
             permanent: false,
@@ -53,7 +63,10 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
       }
       break;
     case 'NON_COUPLE_USER':
-      if (unauthorizedPagesForNonCoupleUser.includes(path)) {
+      if (
+        unauthorizedPagesForNonCoupleUser.includes(path) ||
+        answerRegex.test(path)
+      ) {
         return {
           redirect: {
             permanent: false,

--- a/src/util/userStatusRouting.ts
+++ b/src/util/userStatusRouting.ts
@@ -29,16 +29,10 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
   ];
 
   const path = context.resolvedUrl;
-  console.log('res.data.userStatus: ', res.data.userStatus);
 
-  console.log('path: ', path);
-  // TODO: userStatus에 따라 라우팅 불가하게끔 해야 함
   switch (res.data.userStatus) {
     case 'COUPLE_USER':
-      console.log('coupleuser 임');
-
       if (unauthorizedPagesForCoupleUser.includes(path)) {
-        console.log('coupleuser 페이지 접근 불가 처리됨');
         return {
           redirect: {
             permanent: false,
@@ -48,9 +42,7 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
       }
       break;
     case 'COUPLE_WAITING_USER':
-      console.log('couplewaitinguser 임');
       if (unauthorizedPagesForCoupleWaitingUser.includes(path)) {
-        console.log('couplewaitinguser 페이지 접근 불가 처리됨');
         return {
           redirect: {
             permanent: false,
@@ -60,9 +52,7 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
       }
       break;
     case 'NON_COUPLE_USER':
-      console.log('noncoupleuser 임');
       if (unauthorizedPagesForNonCoupleUser.includes(path)) {
-        console.log('noncoupleuser 페이지 접근 불가 처리됨');
         return {
           redirect: {
             permanent: false,

--- a/src/util/userStatusRouting.ts
+++ b/src/util/userStatusRouting.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+import { parseCookies } from 'nookies';
+import { ACCESS_TOKEN } from '@/constants/auth';
+import { setAuthHeader } from '@/libs/token';
+import { GetServerSidePropsContext } from 'next';
+
+export const userStatusRouting = async (context: GetServerSidePropsContext) => {
+  const instance = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_BACKEND_URL,
+    timeout: 15000,
+  });
+
+  const cookies = parseCookies(context);
+  const accessToken = cookies[ACCESS_TOKEN];
+  setAuthHeader(instance, accessToken);
+
+  const res = await instance.get(`/api/v1/members/user-status`);
+
+  const unauthorizedPagesForCoupleUser = ['/onboarding', '/invite'];
+  const unauthorizedPagesForCoupleWaitingUser = [
+    '/onboarding',
+    '/invite',
+    '/answer',
+  ];
+  const unauthorizedPagesForNonCoupleUser = [
+    '/answer',
+    '/questions',
+    // '/chatroom', -> chatroom에 들어가면 onboarding으로 리다이렉트되기 때문에 넣으면 안됨
+  ];
+
+  const path = context.resolvedUrl;
+  console.log('res.data.userStatus: ', res.data.userStatus);
+
+  console.log('path: ', path);
+  // TODO: userStatus에 따라 라우팅 불가하게끔 해야 함
+  switch (res.data.userStatus) {
+    case 'COUPLE_USER':
+      console.log('coupleuser 임');
+
+      if (unauthorizedPagesForCoupleUser.includes(path)) {
+        console.log('coupleuser 페이지 접근 불가 처리됨');
+        return {
+          redirect: {
+            permanent: false,
+            destination: '/',
+          },
+        };
+      }
+      break;
+    case 'COUPLE_WAITING_USER':
+      console.log('couplewaitinguser 임');
+      if (unauthorizedPagesForCoupleWaitingUser.includes(path)) {
+        console.log('couplewaitinguser 페이지 접근 불가 처리됨');
+        return {
+          redirect: {
+            permanent: false,
+            destination: '/',
+          },
+        };
+      }
+      break;
+    case 'NON_COUPLE_USER':
+      console.log('noncoupleuser 임');
+      if (unauthorizedPagesForNonCoupleUser.includes(path)) {
+        console.log('noncoupleuser 페이지 접근 불가 처리됨');
+        return {
+          redirect: {
+            permanent: false,
+            destination: '/',
+          },
+        };
+      }
+
+      break;
+  }
+};

--- a/src/util/userStatusRouting.ts
+++ b/src/util/userStatusRouting.ts
@@ -16,6 +16,7 @@ export const userStatusRouting = async (context: GetServerSidePropsContext) => {
 
   const res = await instance.get(`/api/v1/members/user-status`);
 
+  // TODO: /invite/[id], /answer/[id] 정규표현식 처리하기
   const unauthorizedPagesForCoupleUser = ['/onboarding', '/invite'];
   const unauthorizedPagesForCoupleWaitingUser = [
     '/onboarding',


### PR DESCRIPTION
## #️⃣연관된 이슈

#94 

## 📝작업 내용
- disallowAccess 함수를 추가하고 각 페이지의 getServerSideProps에서 사용하였습니다.
  ```tsx
  const redirection = await disallowAccess(context);

  if (redirection) {
    return redirection;
  }
  ```
- disallowAccess함수에서는 API로 유저 상태를 받아온 다음, 유저 상태에 따라 정규식을 사용하여 페이지 이동을 막는 기능을 추가했습니다.
  ```tsx
    const disallowedPaths: Record<UserStatus, RegExp[]> = {
      // 커플인 유저의 경우
      COUPLE_USER: [pathPatterns.onboarding, pathPatterns.invite],
      // 커플 대기중인 유저의 경우
      COUPLE_WAITING_USER: [
        pathPatterns.onboarding,
        pathPatterns.answer,
        pathPatterns.invite,
      ],
      // 커플이 아닌 유저의 경우
      NON_COUPLE_USER: [pathPatterns.questions, pathPatterns.answer],
    };
  ```
- serversideApi를 disallowAccess 함수 내부에서 적용하였습니다.
- /chatroom에서 유저 상태에 따라 ui를 다르게 적용하고 리다이렉트하는 기능을 추가했습니다.
  - 커플일 때: 정상적인 대화 목록 렌더링
  - 커플 대기 상태일 때: 임시 대기 ui 렌더링
  - 커플이 아닐 때: /onboarding으로 리다이렉트
  
- 404 페이지에 '홈으로 돌아가기' 버튼을 추가하였습니다.

## 💬리뷰 요구사항
