### PR TITLE
fix: 날짜 차이 구하는 로직 수정

### DIFF
--- a/src/util/applyDateFormatting.ts
+++ b/src/util/applyDateFormatting.ts
@@ -1,22 +1,33 @@
 export const applyDateFormatting = (chatDate: string) => {
-  const parsedChatDate = new Date(Date.parse(chatDate));
+  const getDifferenceInDays = () => {
+    const past = new Date(chatDate).getTime();
+    const current = new Date().getTime();
+    const differenceInDays = Math.abs(current - past);
+    const diffDays = Math.floor(differenceInDays / (1000 * 60 * 60 * 24));
+    return diffDays;
+  };
 
-  const chatYear = parsedChatDate.getFullYear();
-  const chatMonth = parsedChatDate.getMonth() + 1;
-  const chatDay = parsedChatDate.getDate();
-
-  const currentDay = new Date().getDate();
+  const getYYMMDD = () => {
+    const parsedChatDate = new Date(Date.parse(chatDate));
+    const year = parsedChatDate.getFullYear();
+    const month = parsedChatDate.getMonth() + 1;
+    const day = parsedChatDate.getDate();
+    return `${year}년 ${month}월 ${day}일`;
+  };
 
   const getFormattedDate = () => {
-    if (currentDay - chatDay === 0) {
+    const diffDays = getDifferenceInDays();
+    const YYMMDD = getYYMMDD();
+    if (diffDays === 0) {
       return '오늘';
-    } else if (currentDay - chatDay < 4) {
-      return `${currentDay - chatDay}일 전`;
+    } else if (diffDays > 0 && diffDays < 4) {
+      return `${diffDays}일 전`;
     } else {
-      return `${chatYear}년 ${chatMonth}월 ${chatDay}일`;
+      return YYMMDD;
     }
   };
 
   const formattedDate = getFormattedDate();
+
   return formattedDate;
 };


### PR DESCRIPTION
## 📝작업 내용
날짜 차이를 구하는 로직이 잘못되어 이를 수정하였습니다.

### 기존 로직
- '현재 일자 - 과거 일자'를 구하여 'n일 전'을 구현
- 2월 1일과 1월 31일의 차이를 구할 때 1일 - 31일 -> '-30일'이 되는 문제 발생

### 수정된 로직
- 날짜의 차이를 초까지 구하여 (1000 * 60 * 60 * 24)으로 나누어 'n일 전' 구현