### PR TITLE
Fix/allow access

### DIFF
--- a/src/util/disallowAccess.ts
+++ b/src/util/disallowAccess.ts
@@ -43,8 +43,9 @@ export const disallowAccess = async (context: GetServerSidePropsContext) => {
       };
     }
   } catch (error: unknown) {
-    // fetchData가 실패했는데, 로그인이 안돼서 실패한 경우일 때 페이지 접근을 막지 않음(로그인이 안된 상태에서 /invite 접근 가능)
-    // /invite에는 authCheck가 없기 때문에 아래의 코드가 필요함
+    // fetchData가 실패했는데, 로그인이 안돼서 실패한 경우일 때 페이지 접근을 막지 않음(로그인이 안된 상태에서 /invite 접근 가능하도록)
+    // /invite에는 authCheck가 없기 때문에 아래의 코드가 필요함.
+    // 다른 페이지는 authCheck를 하기 때문에 로그인을 안했으면 /로 redirect되어 아래 코드가 실행되지 않음
     const errorResponse = error as ErrorResponse;
     if (errorResponse.status === 401 && errorResponse.code === 'AU001') {
       return;

--- a/src/util/disallowAccess.ts
+++ b/src/util/disallowAccess.ts
@@ -1,6 +1,6 @@
 import { GetServerSidePropsContext } from 'next';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
-import type { UserData, UserStatus } from '@/types/api';
+import type { ErrorResponse, UserData, UserStatus } from '@/types/api';
 
 export const disallowAccess = async (context: GetServerSidePropsContext) => {
   const api = createServerSideInstance(context);
@@ -42,7 +42,14 @@ export const disallowAccess = async (context: GetServerSidePropsContext) => {
         },
       };
     }
-  } catch (error) {
+  } catch (error: unknown) {
+    // fetchData가 실패했는데, 로그인이 안돼서 실패한 경우일 때 페이지 접근을 막지 않음(로그인이 안된 상태에서 /invite 접근 가능)
+    // /invite에는 authCheck가 없기 때문에 아래의 코드가 필요함
+    const errorResponse = error as ErrorResponse;
+    if (errorResponse.status === 401 && errorResponse.code === 'AU001') {
+      return;
+    }
+
     return {
       redirect: {
         permanent: false,


### PR DESCRIPTION
## #️⃣연관된 이슈

#104 

## 📝작업 내용
- 로그인을 안한 상태에서 /invite에 접근 가능하도록 수정하였습니다.
  - 유저 상태를 가져오는 함수 getUserStatus의 catch문에 아래의 코드를 추가하였습니다.
  ```ts
  // fetchData가 실패했는데, 로그인이 안돼서 실패한 경우일 때 페이지 접근을 막지 않음(로그인이 안된 상태에서 /invite 접근 가능하도록)
  // /invite에는 authCheck가 없기 때문에 아래의 코드가 필요함.
  // 다른 페이지는 authCheck를 하기 때문에 로그인을 안했으면 /로 redirect되어 아래 코드가 실행되지 않음
  const errorResponse = error as ErrorResponse;
  if (errorResponse.status === 401 && errorResponse.code === 'AU001') {
    return;
  }
  ```
  - disallowAccess는 토큰을 헤더에 넣어 보내고 유저 상태를 가져오는데, 로그인을 안하고 /invite에 접근했을 경우 토큰이 없어 401 에러가 나게 됩니다.
  - 하지만 로그인을 안하고 /invite에 접근할 경우 토큰이 없어 401 에러가 나는 것이 당연하므로, 401 에러시에는 예외적으로 /로 이동하지 않도록 설정하는 코드를 추가하였습니다.
 
## 💬리뷰 요구사항
어떤 역할을 하는 코드인지 바로 해석하기 어려운 것 같아 다른 방법은 없을지 고민이 됩니다. 