### PR TITLE
fix: interceptor구현 수정

### DIFF
--- a/src/libs/clientSideApi.ts
+++ b/src/libs/clientSideApi.ts
@@ -85,6 +85,9 @@ async function refreshTokenAndRetryRequest(
   }
   setAuthHeader(refreshInstance, existingAccessToken);
 
+  if (!failedRequestConfig) return;
+  if (!failedRequestConfig.headers) return;
+
   try {
     const res = await refreshInstance.post('/api/v1/members/auth/token');
 
@@ -93,6 +96,7 @@ async function refreshTokenAndRetryRequest(
 
       setAccessToken(accessToken);
       setAuthHeader(failedRequestInstance, accessToken);
+      failedRequestConfig.headers.Authorization = `Bearer ${accessToken}`;
 
       // 기존 요청 재시도
       return failedRequestInstance(failedRequestConfig);

--- a/src/libs/serversideApi.ts
+++ b/src/libs/serversideApi.ts
@@ -48,7 +48,7 @@ export const createServerSideInstance = (
       // code : AU001 : 토큰 삭제->  로그인 페이지로 이동
       if (errorResponse.code === ERROR_CODES.INVALID_ACCESS_TOKEN) {
         removeServersideAccessToken(context);
-        // window.location.href = '/';
+        window.location.href = '/';
         return Promise.reject(error.response.data as ErrorResponse);
       }
 
@@ -87,6 +87,9 @@ async function refreshTokenAndRetryRequest(
   }
   setAuthHeader(refreshInstance, existingAccessToken);
 
+  if (!failedRequestConfig) return;
+  if (!failedRequestConfig.headers) return;
+
   try {
     const res = await refreshInstance.post('/api/v1/members/auth/token');
 
@@ -95,11 +98,10 @@ async function refreshTokenAndRetryRequest(
 
       setServersideAccessToken(context, accessToken);
       setAuthHeader(failedRequestInstance, accessToken);
+      failedRequestConfig.headers.Authorization = `Bearer ${accessToken}`;
 
       // 기존 요청 재시도
-      return failedRequestInstance(failedRequestConfig).then((res) => {
-        return Promise.resolve(res);
-      });
+      return failedRequestInstance(failedRequestConfig);
     }
   } catch (error) {
     const axiosError = error as AxiosError;


### PR DESCRIPTION
## #️⃣연관된 이슈

> #107 
서버사이드에서 api 요청을 위해 구현한 createServerSideInstance에서 서버사이드 api 요청시 401 에러 ( 토큰 만료-> 새로운 액세스 토큰 발급)관련 에러를 처리하지 못해서 발생하는 에러 수정

## 📝작업 내용

createServerSideInstance와, 클라이언트 사이드 axios instance의 인터셉터 로직을 수정했습니다. 


```ts
if (res.status === 201) {
      const accessToken = res.headers['authorization'].split(' ')[1];

      setServersideAccessToken(context, accessToken);
      setAuthHeader(failedRequestInstance, accessToken);  <- 이 부분이 없어도 동작하는데, 추후에 불필요하다고 판단되면 삭제 예정 
      failedRequestConfig.headers.Authorization = `Bearer ${accessToken}`; <- 이 부분 수정 

      // 기존 요청 재시도
      return failedRequestInstance(failedRequestConfig);
    }
```

새로운 액세스 토큰을 받아와서 기존에 실패했던 요청의 header에 새로운 액세스 토큰으로 헤더를 설정하는 방식이 잘못되어 수정했습니다. 