### PR TITLE
온보딩단계에서 사용자 입력데이터 새로고침시에도 유지되도록 수정 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-dom": "^18",
         "react-error-boundary": "^4.0.12",
         "react-hot-toast": "^2.4.1",
-        "recoil": "^0.7.7"
+        "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -3912,6 +3913,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "react-dom": "^18",
     "react-error-boundary": "^4.0.12",
     "react-hot-toast": "^2.4.1",
-    "recoil": "^0.7.7"
+    "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/components/onboarding/AnswerStep.tsx
+++ b/src/components/onboarding/AnswerStep.tsx
@@ -1,12 +1,20 @@
 import { useRecoilState } from 'recoil';
-import { onboardingState } from '@/store/onboardingState';
+import {
+  initialOnboardingState,
+  onboardingState,
+} from '@/store/onboardingState';
 import type { OnboardingStepProps } from './Intro';
 import useInput from '@/hooks/common/useInput';
 import AnswerForm from '@/components/answer/AnswerForm';
 import QuestionTitle from '@/components/answer/QuestionTitle';
+import { useSSR } from '@/hooks/common/useSSR';
+import { useEffect } from 'react';
 
 export default function AnswerStep({ onNext }: OnboardingStepProps) {
-  const [onboardingData, setOnboardingData] = useRecoilState(onboardingState);
+  const [onboardingData, setOnboardingData] = useSSR(
+    onboardingState,
+    initialOnboardingState
+  );
 
   const onChangeCallback = (newAnswer: string) => {
     setOnboardingData((prevState) => ({
@@ -30,6 +38,7 @@ export default function AnswerStep({ onNext }: OnboardingStepProps) {
 
     onNext();
   };
+  // console.log('recoil', onboardingData.answer);
 
   return (
     <>

--- a/src/components/onboarding/AnswerStep.tsx
+++ b/src/components/onboarding/AnswerStep.tsx
@@ -1,51 +1,51 @@
-import { useRecoilState } from 'recoil';
+import { type ChangeEventHandler, useState } from 'react';
 import {
   initialOnboardingState,
   onboardingState,
 } from '@/store/onboardingState';
 import type { OnboardingStepProps } from './Intro';
-import useInput from '@/hooks/common/useInput';
+
 import AnswerForm from '@/components/answer/AnswerForm';
 import QuestionTitle from '@/components/answer/QuestionTitle';
 import { useSSR } from '@/hooks/common/useSSR';
-import { useEffect } from 'react';
 
 export default function AnswerStep({ onNext }: OnboardingStepProps) {
   const [onboardingData, setOnboardingData] = useSSR(
     onboardingState,
     initialOnboardingState
   );
+  const [errorMessage, setErrorErrorMessage] = useState('');
 
-  const onChangeCallback = (newAnswer: string) => {
+  const onChange: ChangeEventHandler<
+    HTMLInputElement | HTMLTextAreaElement
+  > = ({ target }) => {
+    const { value } = target;
+
     setOnboardingData((prevState) => ({
       ...prevState,
-      answer: newAnswer,
+      answer: value,
     }));
-  };
 
-  const [answer, onChange, errorMessage] = useInput(
-    onboardingData.answer,
-    (value) => (value.trim() ? '' : '답변을 입력해주세요'),
-    onChangeCallback
-  );
+    const errorMessage = value.trim() ? '' : '답변을 입력해주세요';
+    setErrorErrorMessage(errorMessage);
+  };
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    if (!answer) {
+    if (!onboardingData.answer) {
       return;
     }
 
     onNext();
   };
-  // console.log('recoil', onboardingData.answer);
 
   return (
     <>
       <QuestionTitle question={onboardingData.selectedQuestion.question} />
       <p className="text-lg font-semibold">내가 먼저 답변을 작성해볼까요?</p>
       <AnswerForm
-        answer={answer}
+        answer={onboardingData.answer}
         onChange={onChange}
         errorMessage={errorMessage}
         handleSubmit={handleSubmit}

--- a/src/components/onboarding/AnswerStep.tsx
+++ b/src/components/onboarding/AnswerStep.tsx
@@ -7,10 +7,10 @@ import type { OnboardingStepProps } from './Intro';
 
 import AnswerForm from '@/components/answer/AnswerForm';
 import QuestionTitle from '@/components/answer/QuestionTitle';
-import { useSSR } from '@/hooks/common/useSSR';
+import { useRecoilStateSSR } from '@/hooks/common/useRecoilStateSSR';
 
 export default function AnswerStep({ onNext }: OnboardingStepProps) {
-  const [onboardingData, setOnboardingData] = useSSR(
+  const [onboardingData, setOnboardingData] = useRecoilStateSSR(
     onboardingState,
     initialOnboardingState
   );

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -1,18 +1,21 @@
 import { useRouter } from 'next/router';
-import { useRecoilState } from 'recoil';
+import { useQueryClient } from '@tanstack/react-query';
 import Button from '@/components/ui/Button';
 import {
   initialOnboardingState,
   onboardingState,
 } from '@/store/onboardingState';
+import { useRecoilStateSSR } from '@/hooks/common/useRecoilStateSSR';
 import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import { showToastSuccessMessage } from '@/util/toast';
 import NotificationCard from './NotificationCard';
-import { useQueryClient } from '@tanstack/react-query';
 
 export default function InviteStep() {
   const router = useRouter();
-  const [onboardingData, setOnboardingData] = useRecoilState(onboardingState);
+  const [onboardingData, setOnboardingData] = useRecoilStateSSR(
+    onboardingState,
+    initialOnboardingState
+  );
   const { mutate: createInviteKey, isPending, isError } = useCreateInviteKey();
   const queryClient = useQueryClient();
 
@@ -27,7 +30,7 @@ export default function InviteStep() {
           showToastSuccessMessage('초대링크가 생성되었습니다!');
           router.push('/chatroom');
           queryClient.invalidateQueries({ queryKey: ['user-status'] });
-          // setOnboardingData(initialOnboardingState);
+          setOnboardingData(initialOnboardingState);
         },
       }
     );

--- a/src/components/onboarding/QuestionSelectStep.tsx
+++ b/src/components/onboarding/QuestionSelectStep.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/store/onboardingState';
 import { Question } from '@/types/api';
 import Button from '@/components/ui/Button';
-import { useSSR } from '@/hooks/common/useSSR';
+import { useRecoilStateSSR } from '@/hooks/common/useRecoilStateSSR';
 
 type QuestionSelectStepProps = OnboardingStepProps & {
   questionList: Question[];
@@ -16,11 +16,10 @@ export default function QuestionSelectStep({
   onNext,
   questionList,
 }: QuestionSelectStepProps) {
-  const [onboardingData, setOnboardingData] = useSSR(
+  const [onboardingData, setOnboardingData] = useRecoilStateSSR(
     onboardingState,
     initialOnboardingState
   );
-  // useRecoilState(onboardingState);
 
   const handleSelectQuestion = (question: Question) => {
     setOnboardingData({

--- a/src/components/onboarding/QuestionSelectStep.tsx
+++ b/src/components/onboarding/QuestionSelectStep.tsx
@@ -1,8 +1,12 @@
 import { useRecoilState } from 'recoil';
 import type { OnboardingStepProps } from './Intro';
-import { onboardingState } from '@/store/onboardingState';
+import {
+  initialOnboardingState,
+  onboardingState,
+} from '@/store/onboardingState';
 import { Question } from '@/types/api';
 import Button from '@/components/ui/Button';
+import { useSSR } from '@/hooks/common/useSSR';
 
 type QuestionSelectStepProps = OnboardingStepProps & {
   questionList: Question[];
@@ -12,7 +16,11 @@ export default function QuestionSelectStep({
   onNext,
   questionList,
 }: QuestionSelectStepProps) {
-  const [onboardingData, setOnboardingData] = useRecoilState(onboardingState);
+  const [onboardingData, setOnboardingData] = useSSR(
+    onboardingState,
+    initialOnboardingState
+  );
+  // useRecoilState(onboardingState);
 
   const handleSelectQuestion = (question: Question) => {
     setOnboardingData({
@@ -37,6 +45,7 @@ export default function QuestionSelectStep({
         : ' border-gray-light bg-secondary';
     return `${baseClasses} ${selectedClasses}`;
   };
+  console.log('recoil', onboardingData.selectedQuestion.questionId);
 
   return (
     <>

--- a/src/hooks/common/useInput.ts
+++ b/src/hooks/common/useInput.ts
@@ -7,9 +7,8 @@ type ReturnType = [
 ];
 
 const useInput = (
-  initialValue = '',
-  validator = (value: string) => '',
-  onChangeCallback = (value: string) => {}
+  initialValue: string,
+  validator = (value: string) => ''
 ): ReturnType => {
   const [state, setState] = useState(initialValue);
   const [error, setError] = useState('');
@@ -22,10 +21,8 @@ const useInput = (
 
         const error = validator(value);
         setError(error);
-
-        onChangeCallback(value);
       },
-      [validator, onChangeCallback]
+      [validator]
     );
 
   return [state, onChange, error];

--- a/src/hooks/common/useRecoilStateSSR.ts
+++ b/src/hooks/common/useRecoilStateSSR.ts
@@ -1,7 +1,10 @@
 import { useState, useEffect } from 'react';
 import { type RecoilState, useRecoilState } from 'recoil';
 
-export function useSSR<T>(recoilState: RecoilState<T>, defaultValue: T) {
+export function useRecoilStateSSR<T>(
+  recoilState: RecoilState<T>,
+  defaultValue: T
+) {
   const [isInitial, setIsInitial] = useState(true);
   const [value, setValue] = useRecoilState(recoilState);
 

--- a/src/hooks/common/useSSR.ts
+++ b/src/hooks/common/useSSR.ts
@@ -1,0 +1,13 @@
+import { useState, useEffect } from 'react';
+import { type RecoilState, useRecoilState } from 'recoil';
+
+export function useSSR<T>(recoilState: RecoilState<T>, defaultValue: T) {
+  const [isInitial, setIsInitial] = useState(true);
+  const [value, setValue] = useRecoilState(recoilState);
+
+  useEffect(() => {
+    setIsInitial(false);
+  }, []);
+
+  return [isInitial ? defaultValue : value, setValue] as const;
+}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -14,10 +14,6 @@ export default function Document() {
           crossOrigin="anonymous"
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-dynamic-subset.min.css"
         />
-        <meta
-          http-equiv="Content-Security-Policy"
-          content="upgrade-insecure-requests"
-        />
       </Head>
       <body>
         <Main />

--- a/src/store/onboardingState.ts
+++ b/src/store/onboardingState.ts
@@ -1,4 +1,7 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const initialOnboardingState = {
   selectedQuestion: {
@@ -8,7 +11,8 @@ export const initialOnboardingState = {
   answer: '',
 };
 
-export const onboardingState = atom({
+export const onboardingState = atom<typeof initialOnboardingState>({
   key: 'onboardingState',
   default: initialOnboardingState,
+  effects_UNSTABLE: [persistAtom],
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91 

## 📝작업 내용

온보딩 단계에서 사용자의 입력 데이터가 페이지 새로고침 후에도 유지되도록 기능을 구현했습니다.

1. Recoil-Persist의 도입
- recoil로 관리되고 있는 사용자의 입력데이터를 유지하기 위해서 recoil-persist를 도입했습니다. 
(recoil 공식문서에 있는 Atom Effects로 상태를 유지하는 기능을 구현하려고 했는데, SSR에서의 하이드레이션 문제 해결 방법을 찾기 어려워서 recoil-persist로 구현했습니다.) 

2. SSR 하이드레이션 문제 해결 (useRecoilStateSSR)
- SSR에서의 하이드레이션 문제를 해결하기 위해서 [recoil-persist라이브러리에서 제안하는 ssr 대응 방식](https://github.com/polemius/recoil-persist#server-side-rendering)을 이용해서 해결했습니다. 
```ts
import { useState, useEffect } from 'react';
import { type RecoilState, useRecoilState } from 'recoil';

export function useRecoilStateSSR<T>(
  recoilState: RecoilState<T>,
  defaultValue: T
) {
  const [isInitial, setIsInitial] = useState(true);
  const [value, setValue] = useRecoilState(recoilState);

  useEffect(() => {
    setIsInitial(false);
  }, []);

  return [isInitial ? defaultValue : value, setValue] as const;
}

```
3. AnswerStep의 사용자 입력데이터 관리로직 수정 
- AnswerStep에서  useInput 훅을 사용해서 폼 데이터를 관리하던 부분을 수정했습니다.
- 그런데, Recoil 상태가 유지되는 반면, useInput 훅에 의해 관리되는 answer 상태가 초기값 ''으로 유지되는 문제가 발견되었습니다. (useInput으로 관리하는 answer state는  useInput훅이 처음 호출되는 시점에 전달한 `''` 값이 이어서 발생한 문제)
    <img src="https://github.com/coding-union-kr/youare-iam-fe/assets/96093996/c0879071-e0f8-4180-bc5e-3c99c8ebc73a" width="250">
- 답변 등록페이지에서도 useInput 훅을 사용하고 있기 때문에 useInput구현을 수정하지 않고,  AnswerStep에서 입력데이터 관리 방식을 recoil 상태를 직접 사용하는 방식으로 변경해서 해당 문제를 해결했습니다. 

4. useInput훅의 구현 변경
- 이렇게 변경하고 나니, useInput 구현에서 `onChangeCallback`인자가 더 이상 사용되지 않기 때문에 useInput의 구현도 수정했습니다. 

---
- 서버와 통신하기 위해서 전에 추가했던 meta tag가 현재 서버 통신에서는 문제가 되고 있어서 이부분도 삭제했습니다. 
