### PR TITLE
refactor: 쿼리 키 상수로 분리

### DIFF
--- a/src/components/chatroom/ChatList.tsx
+++ b/src/components/chatroom/ChatList.tsx
@@ -6,6 +6,7 @@ import { get } from '@/libs/clientSideApi';
 import { myIdState } from '@/store/myIdState';
 import { useSetRecoilState } from 'recoil';
 import { useInfiniteQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/constants/queryKeys';
 
 type Letter = {
   selectQuestionId: number;
@@ -57,7 +58,7 @@ const ChatList = ({ setModalInfo, setIsModalOpen }: ChatList) => {
   };
 
   const { fetchNextPage, hasNextPage, data } = useInfiniteQuery({
-    queryKey: ['letters'],
+    queryKey: queryKeys.letters,
     queryFn: getLetters,
     initialPageParam: 0,
 

--- a/src/components/onboarding/InviteStep.tsx
+++ b/src/components/onboarding/InviteStep.tsx
@@ -9,6 +9,7 @@ import { useRecoilStateSSR } from '@/hooks/common/useRecoilStateSSR';
 import { useCreateInviteKey } from '@/hooks/queries/useCreateInviteKey';
 import { showToastSuccessMessage } from '@/util/toast';
 import NotificationCard from './NotificationCard';
+import { queryKeys } from '@/constants/queryKeys';
 
 export default function InviteStep() {
   const router = useRouter();
@@ -29,7 +30,7 @@ export default function InviteStep() {
         onSuccess: ({ data }) => {
           showToastSuccessMessage('초대링크가 생성되었습니다!');
           router.push('/chatroom');
-          queryClient.invalidateQueries({ queryKey: ['user-status'] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.userStatus });
           setOnboardingData(initialOnboardingState);
         },
       }

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -1,0 +1,7 @@
+export const queryKeys = {
+  letters: ['letters'],
+  questions: ['questions'],
+  question: (id: number) => ['question', id],
+  userStatus: ['userStatus'],
+  invitationInfo: ['invitationInfo'],
+};

--- a/src/hooks/queries/useInvitationInfo.ts
+++ b/src/hooks/queries/useInvitationInfo.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { get } from '@/libs/clientSideApi';
+import { queryKeys } from '@/constants/queryKeys';
 
 type InvitationInfo = {
   question: string;
@@ -25,7 +26,7 @@ export default function useInvitationInfo(linkKey: string) {
     isLoading,
     isError,
   } = useQuery<InvitationInfo>({
-    queryKey: ['invitationInfo'],
+    queryKey: queryKeys.invitationInfo,
     queryFn: () => getInvitationInfo(linkKey),
   });
   return { info, error, isLoading, isError };

--- a/src/hooks/queries/useQuestion.ts
+++ b/src/hooks/queries/useQuestion.ts
@@ -1,3 +1,4 @@
+import { queryKeys } from '@/constants/queryKeys';
 import { get } from '@/libs/clientSideApi';
 import { useQuery } from '@tanstack/react-query';
 
@@ -19,7 +20,7 @@ export default function useQuestion(id: number) {
     isLoading,
     isError,
   } = useQuery<string>({
-    queryKey: ['question', id],
+    queryKey: queryKeys.question(id),
     queryFn: () => getQuestion(id),
   });
 

--- a/src/hooks/queries/useQuestionList.ts
+++ b/src/hooks/queries/useQuestionList.ts
@@ -1,3 +1,4 @@
+import { queryKeys } from '@/constants/queryKeys';
 import { get } from '@/libs/clientSideApi';
 import { Question } from '@/types/api';
 import { useQuery } from '@tanstack/react-query';
@@ -16,7 +17,7 @@ export default function useQuestionList() {
     isLoading,
     isError,
   } = useQuery<Question[]>({
-    queryKey: ['question-list'],
+    queryKey: queryKeys.questions,
     queryFn: getQuestionList,
   });
 

--- a/src/hooks/queries/useUserStatus.ts
+++ b/src/hooks/queries/useUserStatus.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import type { UserData } from '@/types/api';
 import { get } from '@/libs/clientSideApi';
+import { queryKeys } from '@/constants/queryKeys';
 
 const getUserStatus = async () => {
   const res = await get<UserData>('/api/v1/members/user-status');
@@ -14,7 +15,7 @@ export default function useUserStatus(isAuthenticated: boolean) {
     isLoading,
     isError,
   } = useQuery<UserData>({
-    queryKey: ['user-status'],
+    queryKey: queryKeys.userStatus,
     queryFn: getUserStatus,
     enabled: isAuthenticated,
   });

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -13,6 +13,7 @@ import { checkAuth } from '@/util/checkAuth';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import { Question } from '@/types/api';
 import { disallowAccess } from '@/util/disallowAccess';
+import { queryKeys } from '@/constants/queryKeys';
 
 type Prop = {
   id: string;
@@ -41,7 +42,7 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
       { selectQuestionId: Number(selectQuestionId), answer },
       {
         onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ['letters'] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.letters });
           router.push({
             pathname: '/chatroom',
             hash: selectQuestionId,
@@ -92,7 +93,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   };
 
   await queryClient.prefetchQuery({
-    queryKey: ['question', id],
+    queryKey: queryKeys.question(Number(id)),
     queryFn: () => getQuestion(Number(id)),
   });
 

--- a/src/pages/invite/[id]/index.tsx
+++ b/src/pages/invite/[id]/index.tsx
@@ -14,6 +14,7 @@ import usePostInviteAnswer from '@/hooks/queries/usePostInviteAnswer';
 import { get } from '@/libs/clientSideApi';
 import useAuth from '@/hooks/auth/useAuth';
 import { invitePageAccess } from '@/util/invitePageAccess';
+import { queryKeys } from '@/constants/queryKeys';
 
 type InviteData = {
   data: {
@@ -45,8 +46,8 @@ const Page: NextPageWithLayout<InviteData> = ({ data, id }) => {
         { linkKey: id, answer: text },
         {
           onSuccess: () => {
-            queryClient.invalidateQueries({ queryKey: ['letters'] });
-            queryClient.invalidateQueries({ queryKey: ['user-status'] });
+            queryClient.invalidateQueries({ queryKey: queryKeys.letters });
+            queryClient.invalidateQueries({ queryKey: queryKeys.userStatus });
             window.localStorage.removeItem(
               LOCAL_STORAGE_KEYS.TEXT_AREA_CONTENT
             );

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -10,6 +10,7 @@ import { checkAuth } from '@/util/checkAuth';
 import usePostQuestion from '@/hooks/queries/usePostQuestion';
 import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import { disallowAccess } from '@/util/disallowAccess';
+import { queryKeys } from '@/constants/queryKeys';
 
 type Questions = {
   questions: Question[];
@@ -25,8 +26,8 @@ const Page: NextPageWithLayout<Questions> = () => {
       { questionId: questionId },
       {
         onSettled: () => {
-          queryClient.invalidateQueries({ queryKey: ['question-list'] });
-          queryClient.invalidateQueries({ queryKey: ['letters'] });
+          queryClient.invalidateQueries({ queryKey: queryKeys.questions });
+          queryClient.invalidateQueries({ queryKey: queryKeys.letters });
         },
         onSuccess: () => {
           router.push('/chatroom');
@@ -67,7 +68,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const queryClient = new QueryClient();
 
   await queryClient.prefetchQuery({
-    queryKey: ['question-list'],
+    queryKey: queryKeys.questions,
     queryFn: () => fetchData<Question[]>(api, '/questions'),
   });
 

--- a/src/util/invitePageAccess.ts
+++ b/src/util/invitePageAccess.ts
@@ -3,6 +3,7 @@ import { ACCESS_TOKEN } from '@/constants/auth';
 import { parseCookies } from 'nookies';
 import { QueryClient } from '@tanstack/react-query';
 import type { GetServerSidePropsContext } from 'next';
+import { queryKeys } from '@/constants/queryKeys';
 
 type UserStatus = {
   userStatus: string;
@@ -19,7 +20,7 @@ export const invitePageAccess = async (context: GetServerSidePropsContext) => {
   if (accessToken) {
     try {
       const data: UserStatus = await queryClient.fetchQuery({
-        queryKey: ['user-status'],
+        queryKey: queryKeys.userStatus,
         queryFn: () => fetchData(api, '/api/v1/members/user-status'),
       });
       if (


### PR DESCRIPTION
## #️⃣연관된 이슈

> #112 

## 📝작업 내용

프로젝트에서 쿼리 키를 사용하는 코드를 상수로 분리했습니다. 
```ts
export const queryKeys = {
  letters: ['letters'],
  questions: ['questions'],
  question: (id: number) => ['question', id],
  userStatus: ['userStatus'],
  invitationInfo: ['invitationInfo'],
};
```