### PR TITLE
feat: 500 에러 커스텀 페이지 추가

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -5,6 +5,9 @@ const Custom404 = () => {
   return (
     <section>
       <div className="h-screen flex flex-col items-center py-20 justify-between">
+        <div className="font-neo text-2xl mb-4 text-gray-dark">
+          앗, 오류가 발생했어요!
+        </div>
         <div>
           <div className="font-neo text-4xl mb-4 text-primary">
             404 Page Not Found

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,0 +1,28 @@
+import Button from '@/components/ui/Button';
+import { useRouter } from 'next/router';
+
+const Custom500 = () => {
+  const router = useRouter();
+  return (
+    <section>
+      <div className="h-screen flex flex-col items-center py-20 justify-between text-center">
+        <div className="font-neo text-2xl mb-4 text-gray-dark">
+          앗, 오류가 발생했어요!
+        </div>
+        <div>
+          <div className="font-neo text-4xl mb-4 text-primary">
+            500 Server Error
+          </div>
+          <div className="font-neo text-lg mb-4">
+            현재 서비스에 접속할 수 없습니다.
+          </div>
+        </div>
+        <Button onClick={() => router.reload()} variant="primary" size="wide">
+          새로고침하기
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export default Custom500;


### PR DESCRIPTION
## #️⃣연관된 이슈
#121 

## 📝작업 내용
- 500 에러 커스텀 페이지를 추가하였습니다.
- 404 에러 페이지에 '앗, 오류가 발생했어요!'라는 문구를 추가하였습니다.

## 스크린샷 
<img width="200" alt="스크린샷 2024-02-13 오후 6 18 37" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/266636c7-7431-45ed-88be-3c1473503151">
<img width="200" alt="스크린샷 2024-02-13 오후 6 17 36" src="https://github.com/coding-union-kr/youare-iam-fe/assets/101965666/19cc375d-c513-4fcd-90b0-61f2a2764bda">

## 고민한 내용
개발 환경에서 500 에러 발생 시 500 에러 페이지가 뜨지 않는 현상이 있었습니다. 처음에는 오류라고 생각했으나, 배포 환경에서는 500 에러 페이지가 정상적으로 뜨는 것을 확인할 수 있었습니다. 공식 문서에서도 이를 언급하고 있습니다.

공식 문서 설명 링크: https://nextjs.org/docs/pages/building-your-application/data-fetching/get-server-side-props#error-handling