### PR TITLE
Feature/UI fix

### DIFF
--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -56,7 +56,7 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
   return (
     <>
       <SEO title="답변 등록하기" />
-      <section className="flex flex-col justify-between h-full pt-10">
+      <section className="flex flex-col justify-between h-full pt-3">
         <QuestionTitle question={question} />
         <AnswerForm
           answer={answer}
@@ -112,11 +112,11 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     };
   }
 
-  // const redirection = await disallowAccess(context);
+  const redirection = await disallowAccess(context);
 
-  // if (redirection) {
-  //   return redirection;
-  // }
+  if (redirection) {
+    return redirection;
+  }
 
   return {
     props: { id, initialState: dehydrate(queryClient) },

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,13 +2,14 @@ import type { NextPageWithLayout } from '@/types/page';
 import BasicLayout from '@/components/layout/BasicLayout';
 import KakaoLoginButton from '@/components/ui/KakaoLoginButton';
 import Image from 'next/image';
-import useAuth from '@/hooks/auth/useAuth';
 import StartServiceButton from '@/components/ui/ StartServiceButton';
 import SEO from '@/components/SEO/SEO';
+import { GetServerSidePropsContext } from 'next';
+import { isAuthenticated } from '@/util/isAuthenticated';
 
-const Home: NextPageWithLayout = () => {
-  const { isAuthenticated } = useAuth();
-
+const Home: NextPageWithLayout<{ isAuthenticated: boolean }> = (
+  isAuthenticated
+) => {
   return (
     <>
       <SEO />
@@ -35,5 +36,15 @@ Home.getLayout = function getLayout(page) {
     <BasicLayout className="bg-[#F7CBC3] justify-center">{page}</BasicLayout>
   );
 };
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const { authStatus } = await isAuthenticated(context);
+
+  return {
+    props: {
+      isAuthenticated: authStatus,
+    },
+  };
+}
 
 export default Home;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,10 +1,10 @@
+import { GetServerSidePropsContext } from 'next';
+import Image from 'next/image';
 import type { NextPageWithLayout } from '@/types/page';
 import BasicLayout from '@/components/layout/BasicLayout';
 import KakaoLoginButton from '@/components/ui/KakaoLoginButton';
-import Image from 'next/image';
 import StartServiceButton from '@/components/ui/ StartServiceButton';
 import SEO from '@/components/SEO/SEO';
-import { GetServerSidePropsContext } from 'next';
 import { isAuthenticated } from '@/util/isAuthenticated';
 
 const Home: NextPageWithLayout<{ isAuthenticated: boolean }> = (

--- a/src/util/isAuthenticated.ts
+++ b/src/util/isAuthenticated.ts
@@ -1,0 +1,12 @@
+import { ACCESS_TOKEN } from '@/constants/auth';
+import { GetServerSidePropsContext } from 'next';
+import { parseCookies } from 'nookies';
+
+export async function isAuthenticated(context: GetServerSidePropsContext) {
+  const cookies = parseCookies(context);
+  const accessToken = cookies[ACCESS_TOKEN];
+
+  return {
+    authStatus: !!accessToken,
+  };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #139 

## 📝작업 내용

- 답변 등록 페이지 padding 수정 
- 메인 페이지에 로그인 버튼 / 서비스 시작 버튼을 분기하는 기준값이 isAuthenticated 기존에는 useAuth라는 훅을 이용한 클라이언트 사이드 로직이었는데  이를 서버사이드 props로 전달하도록 수정 

### 스크린샷 (선택)

