### PR TITLE
답변 수정하기 페이지 ui 구현 

### DIFF
--- a/src/pages/answer/edit/[id]/index.tsx
+++ b/src/pages/answer/edit/[id]/index.tsx
@@ -1,0 +1,90 @@
+import { GetServerSidePropsContext } from 'next';
+import { QueryClient, dehydrate } from '@tanstack/react-query';
+import PageLayoutWithTitle from '@/components/layout/PageLayoutWithTitle';
+import type { NextPageWithLayout } from '@/types/page';
+import type { Question } from '@/types/api';
+import { checkAuth } from '@/util/checkAuth';
+import { disallowAccess } from '@/util/disallowAccess';
+import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
+import { queryKeys } from '@/constants/queryKeys';
+import useInput from '@/hooks/common/useInput';
+import useQuestion from '@/hooks/queries/useQuestion';
+import QuestionTitle from '@/components/answer/QuestionTitle';
+import AnswerForm from '@/components/answer/AnswerForm';
+import SEO from '@/components/SEO/SEO';
+
+const Page: NextPageWithLayout<{ id: string }> = ({ id }) => {
+  const [answer, onChange, errorMessage] = useInput('', (value) =>
+    value.trim() ? '' : '답변을 입력해주세요'
+  );
+  const { question } = useQuestion(Number(id));
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!answer) {
+      return;
+    }
+
+    //Todo: 답변 수정하기 api 연결
+  };
+
+  return (
+    <>
+      <SEO title="답변 수정하기" />
+      <section className="flex flex-col justify-between h-full pt-3">
+        <QuestionTitle question={question} />
+        <AnswerForm
+          answer={answer}
+          onChange={onChange}
+          errorMessage={errorMessage}
+          handleSubmit={handleSubmit}
+        />
+      </section>
+    </>
+  );
+};
+
+Page.getLayout = function getLayout(page) {
+  return (
+    <>
+      <PageLayoutWithTitle title="답변 수정하기">{page}</PageLayoutWithTitle>
+    </>
+  );
+};
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const authCheck = await checkAuth(context);
+  if (authCheck) {
+    return authCheck;
+  }
+
+  const redirection = await disallowAccess(context);
+
+  if (redirection) {
+    return redirection;
+  }
+
+  const { id } = context.query;
+  const queryClient = new QueryClient();
+  const api = createServerSideInstance(context);
+
+  const getQuestion = async (id: number) => {
+    const data = await fetchData<Question>(
+      api,
+      `/api/v1/answer?selected-question-id=${id}`
+    );
+    return data.question;
+  };
+
+  await queryClient.prefetchQuery({
+    queryKey: queryKeys.question(Number(id)),
+    queryFn: () => getQuestion(Number(id)),
+  });
+
+  return {
+    props: { id, initialState: dehydrate(queryClient) },
+  };
+}
+
+export default Page;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,9 +7,9 @@ import StartServiceButton from '@/components/ui/ StartServiceButton';
 import SEO from '@/components/SEO/SEO';
 import { isAuthenticated } from '@/util/isAuthenticated';
 
-const Home: NextPageWithLayout<{ isAuthenticated: boolean }> = (
-  isAuthenticated
-) => {
+const Home: NextPageWithLayout<{ isAuthenticated: boolean }> = ({
+  isAuthenticated,
+}) => {
   return (
     <>
       <SEO />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #137 

## 📝작업 내용

> 답변 수정하기 페이지 ui  구현 (api 연결 하지 않음) 

- 답변 수정 페이지 경로: `/answer/edit/[id]`
- 답변 작성 페이지 구현을 위해 사용된 로직 재사용 

> #142 에서 ` isAuthenticated` prop이 destructuring 하지 않아서 이 부분 수정 