### PR TITLE
답변 수정페이지 구현

### DIFF
--- a/src/components/chatroom/ChatList.tsx
+++ b/src/components/chatroom/ChatList.tsx
@@ -99,12 +99,12 @@ const ChatList = ({ setModalInfo, setIsModalOpen }: ChatList) => {
     } else if (letter.answerCount === 1) {
       if (letter.myAnswer === true) {
         setModalInfo({
-          actionText: '답변 요청하기',
+          actionText: '답변 수정하기',
           cancelText: '되돌아가기',
           bodyText:
-            '상대가 답변을 등록하지 않았어요.<br>답변을 작성할 수 있도록<br/> 메시지를 보내볼까요?',
+            '상대가 답변을 등록하지 않았어요.<br>기존 답변을 수정하시겠어요?',
           handleAction: () => {
-            kakaoShare(letter.question, letter.selectQuestionId);
+            router.push(`/answer/edit/${letter.selectQuestionId}`);
           },
         });
       } else {

--- a/src/constants/queryKeys.ts
+++ b/src/constants/queryKeys.ts
@@ -4,4 +4,5 @@ export const queryKeys = {
   question: (id: number) => ['question', id],
   userStatus: ['userStatus'],
   invitationInfo: ['invitationInfo'],
+  answer: (id: number) => ['answer', id],
 };

--- a/src/hooks/queries/useAnswer.ts
+++ b/src/hooks/queries/useAnswer.ts
@@ -1,0 +1,35 @@
+import { queryKeys } from '@/constants/queryKeys';
+import { useQuery } from '@tanstack/react-query';
+import type { Answer } from '@/types/api';
+import { get } from '@/libs/clientSideApi';
+import type { AxiosInstance } from 'axios';
+import { fetchData } from '@/libs/serversideApi';
+
+const getExistingAnswerClientSide = async (id: number) => {
+  const res = await get<Answer>(`/api/v1/answer?selected-question-id=${id}`);
+  return res.data.answer;
+};
+
+export const getExistingAnswer = async (api: AxiosInstance, id: number) => {
+  const data = await fetchData<Answer>(
+    api,
+    `/api/v1/answer?selected-question-id=${id}`
+  );
+  return data.answer;
+};
+
+export default function useAnswer(id: number) {
+  const fallbackAnswer = '';
+
+  const {
+    data: existingAnswer = fallbackAnswer,
+    error,
+    isLoading,
+    isError,
+  } = useQuery<string>({
+    queryKey: queryKeys.answer(id),
+    queryFn: () => getExistingAnswerClientSide(id),
+  });
+
+  return { existingAnswer, error, isLoading, isError };
+}

--- a/src/hooks/queries/useEditAnswer.ts
+++ b/src/hooks/queries/useEditAnswer.ts
@@ -1,0 +1,14 @@
+import { type UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { put } from '@/libs/clientSideApi';
+import { Answer } from '@/types/api';
+
+export const useEditAnswer = (
+  options?: UseMutationOptions<void, unknown, Answer>
+) => {
+  return useMutation<void, unknown, Answer>({
+    mutationFn: (data: Answer) => put('/api/v1/answer', data),
+    ...options,
+  });
+};
+
+export default useEditAnswer;

--- a/src/hooks/queries/usePostAnswer.ts
+++ b/src/hooks/queries/usePostAnswer.ts
@@ -1,10 +1,6 @@
 import { type UseMutationOptions, useMutation } from '@tanstack/react-query';
 import { post } from '@/libs/clientSideApi';
-
-type Answer = {
-  selectQuestionId: number;
-  answer: string;
-};
+import { type Answer } from '@/types/api';
 
 export const usePostAnswer = (
   options?: UseMutationOptions<void, unknown, Answer>

--- a/src/hooks/queries/useQuestion.ts
+++ b/src/hooks/queries/useQuestion.ts
@@ -1,19 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { AxiosInstance } from 'axios';
 import { queryKeys } from '@/constants/queryKeys';
 import { get } from '@/libs/clientSideApi';
-import { useQuery } from '@tanstack/react-query';
+import { fetchData } from '@/libs/serversideApi';
 
 type Question = {
   question: string;
 };
 
-export const getQuestion = async (id: number) => {
+export const getQuestionClientSide = async (id: number) => {
   const res = await get<Question>(
     `/api/v1/answer/question?selected-question-id=${id}`
   );
   return res.data.question;
 };
 
-export default function useQuestion(id: number) {
+export const getQuestion = async (api: AxiosInstance, id: number) => {
+  const data = await fetchData<Question>(
+    api,
+    `/api/v1/answer/question?selected-question-id=${id}`
+  );
+  return data.question;
+};
+
+export function useQuestion(id: number) {
   const fallbackQuestion = '';
 
   const {
@@ -23,7 +33,7 @@ export default function useQuestion(id: number) {
     isError,
   } = useQuery<string>({
     queryKey: queryKeys.question(id),
-    queryFn: () => getQuestion(id),
+    queryFn: () => getQuestionClientSide(id),
   });
 
   return { question, error, isLoading, isError };

--- a/src/hooks/queries/useQuestion.ts
+++ b/src/hooks/queries/useQuestion.ts
@@ -7,7 +7,9 @@ type Question = {
 };
 
 export const getQuestion = async (id: number) => {
-  const res = await get<Question>(`/api/v1/answer?selected-question-id=${id}`);
+  const res = await get<Question>(
+    `/api/v1/answer/question?selected-question-id=${id}`
+  );
   return res.data.question;
 };
 

--- a/src/libs/clientSideApi.ts
+++ b/src/libs/clientSideApi.ts
@@ -141,3 +141,10 @@ export const post = <T = any, D = any, R = AxiosResponse<T>>(
 ) => {
   return instance.post<T, R>(url, data);
 };
+
+export const put = <T = any, D = any, R = AxiosResponse<T>>(
+  url: string,
+  data?: D
+) => {
+  return instance.put<T, R>(url, data);
+};

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -1,17 +1,15 @@
 import type { GetServerSidePropsContext } from 'next';
 import { useRouter } from 'next/router';
-
+import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
 import type { NextPageWithLayout } from '@/types/page';
 import PageLayoutWithTitle from '@/components/layout/PageLayoutWithTitle';
 import AnswerForm from '@/components/answer/AnswerForm';
 import QuestionTitle from '@/components/answer/QuestionTitle';
 import useInput from '@/hooks/common/useInput';
 import usePostAnswer from '@/hooks/queries/usePostAnswer';
-import { QueryClient, dehydrate, useQueryClient } from '@tanstack/react-query';
-import useQuestion from '@/hooks/queries/useQuestion';
+import { getQuestion } from '@/hooks/queries/useQuestion';
 import { checkAuth } from '@/util/checkAuth';
-import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
-import { Question } from '@/types/api';
+import { createServerSideInstance } from '@/libs/serversideApi';
 import { disallowAccess } from '@/util/disallowAccess';
 import { queryKeys } from '@/constants/queryKeys';
 import SEO from '@/components/SEO/SEO';
@@ -21,7 +19,7 @@ type Prop = {
   question: string;
 };
 
-const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
+const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId, question }) => {
   const router = useRouter();
   const { mutate: postAnswer, isPending } = usePostAnswer();
 
@@ -29,7 +27,6 @@ const Page: NextPageWithLayout<Prop> = ({ id: selectQuestionId }) => {
     value.trim() ? '' : '답변을 입력해주세요'
   );
 
-  const { question } = useQuestion(Number(selectQuestionId));
   const queryClient = useQueryClient();
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -88,17 +85,9 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const queryClient = new QueryClient();
   const api = createServerSideInstance(context);
 
-  const getQuestion = async (id: number) => {
-    const data = await fetchData<Question>(
-      api,
-      `/api/v1/answer/question?selected-question-id=${id}`
-    );
-    return data.question;
-  };
-
-  await queryClient.prefetchQuery({
+  const data = await queryClient.fetchQuery({
     queryKey: queryKeys.question(Number(id)),
-    queryFn: () => getQuestion(Number(id)),
+    queryFn: () => getQuestion(api, Number(id)),
   });
 
   // Todo: api 응답이 404일 경우에 notfound 페이지를 보여주도록 수정
@@ -119,7 +108,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   }
 
   return {
-    props: { id, initialState: dehydrate(queryClient) },
+    props: { id, question: data, initialState: dehydrate(queryClient) },
   };
 }
 

--- a/src/pages/answer/[id]/index.tsx
+++ b/src/pages/answer/[id]/index.tsx
@@ -91,7 +91,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const getQuestion = async (id: number) => {
     const data = await fetchData<Question>(
       api,
-      `/api/v1/answer?selected-question-id=${id}`
+      `/api/v1/answer/question?selected-question-id=${id}`
     );
     return data.question;
   };

--- a/src/pages/answer/edit/[id]/index.tsx
+++ b/src/pages/answer/edit/[id]/index.tsx
@@ -87,7 +87,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const getQuestion = async (id: number) => {
     const data = await fetchData<Question>(
       api,
-      `/api/v1/answer?selected-question-id=${id}`
+      `/api/v1/answer/question?selected-question-id=${id}`
     );
     return data.question;
   };

--- a/src/pages/answer/edit/[id]/index.tsx
+++ b/src/pages/answer/edit/[id]/index.tsx
@@ -1,5 +1,6 @@
 import { GetServerSidePropsContext } from 'next';
-import { QueryClient, dehydrate } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+import { useQueryClient, QueryClient, dehydrate } from '@tanstack/react-query';
 import PageLayoutWithTitle from '@/components/layout/PageLayoutWithTitle';
 import type { NextPageWithLayout } from '@/types/page';
 import type { Question } from '@/types/api';
@@ -12,12 +13,16 @@ import useQuestion from '@/hooks/queries/useQuestion';
 import QuestionTitle from '@/components/answer/QuestionTitle';
 import AnswerForm from '@/components/answer/AnswerForm';
 import SEO from '@/components/SEO/SEO';
+import useEditAnswer from '@/hooks/queries/useEditAnswer';
 
 const Page: NextPageWithLayout<{ id: string }> = ({ id }) => {
+  const router = useRouter();
   const [answer, onChange, errorMessage] = useInput('', (value) =>
     value.trim() ? '' : '답변을 입력해주세요'
   );
   const { question } = useQuestion(Number(id));
+  const { mutate: editAnswer, isPending } = useEditAnswer();
+  const queryClient = useQueryClient();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -26,7 +31,17 @@ const Page: NextPageWithLayout<{ id: string }> = ({ id }) => {
       return;
     }
 
-    //Todo: 답변 수정하기 api 연결
+    editAnswer(
+      { selectQuestionId: Number(id), answer },
+      {
+        onSuccess: () => {
+          router.push({
+            pathname: '/chatroom',
+            hash: id,
+          });
+        },
+      }
+    );
   };
 
   return (

--- a/src/pages/answer/edit/[id]/index.tsx
+++ b/src/pages/answer/edit/[id]/index.tsx
@@ -3,10 +3,9 @@ import { useRouter } from 'next/router';
 import { useQueryClient, QueryClient, dehydrate } from '@tanstack/react-query';
 import PageLayoutWithTitle from '@/components/layout/PageLayoutWithTitle';
 import type { NextPageWithLayout } from '@/types/page';
-import type { Question } from '@/types/api';
 import { checkAuth } from '@/util/checkAuth';
 import { disallowAccess } from '@/util/disallowAccess';
-import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
+import { createServerSideInstance } from '@/libs/serversideApi';
 import { queryKeys } from '@/constants/queryKeys';
 import useInput from '@/hooks/common/useInput';
 import QuestionTitle from '@/components/answer/QuestionTitle';
@@ -14,6 +13,7 @@ import AnswerForm from '@/components/answer/AnswerForm';
 import SEO from '@/components/SEO/SEO';
 import useEditAnswer from '@/hooks/queries/useEditAnswer';
 import { getExistingAnswer } from '@/hooks/queries/useAnswer';
+import { getQuestion } from '@/hooks/queries/useQuestion';
 
 const Page: NextPageWithLayout<{
   id: string;
@@ -90,18 +90,10 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const queryClient = new QueryClient();
   const api = createServerSideInstance(context);
 
-  const getQuestion = async (id: number) => {
-    const data = await fetchData<Question>(
-      api,
-      `/api/v1/answer/question?selected-question-id=${id}`
-    );
-    return data.question;
-  };
-
   const [question, answer] = await Promise.all([
     queryClient.fetchQuery({
       queryKey: queryKeys.question(Number(id)),
-      queryFn: () => getQuestion(Number(id)),
+      queryFn: () => getQuestion(api, Number(id)),
     }),
     queryClient.fetchQuery({
       queryKey: queryKeys.answer(Number(id)),

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -18,3 +18,8 @@ export type UserData = {
   userStatus: UserStatus;
   linkKey: string;
 };
+
+export type Answer = {
+  selectQuestionId: number;
+  answer: string;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #137

## 📝작업 내용

> 기존 답변 조회 api, 답변 수정 api 연결 

답변작성, 답변 수정 페이지에서 질문조회, 답변 조회하는 방식을 수정했습니다. 
기존에는 getServerSideProps -> prefetchQuery, clientSide에서 useQuery를 사용했었는데
getServerSideProps에서 fetchQuery를 사용해서, api로 받아온 데이터를 직접 props로 페이지 컴포넌트에 넘기는 방식으로 수정했습니다. 
기존 방식에서 클라이언트 사이드에서 추가적인 데이터 로딩을 하기때문에 깜빡임이 있어서 이를 개선했습니다.
