### PR TITLE
질문 선택 페이지에 질문 등록 버튼 추가

### DIFF
--- a/src/components/chatroom/LockedQuestionBar.tsx
+++ b/src/components/chatroom/LockedQuestionBar.tsx
@@ -4,7 +4,7 @@ import LockIcon from '../icons/LockIcon';
 import { applyDateFormatting } from '@/util/applyDateFormatting';
 import type { Letter } from '@/types/api';
 import useDialog from '@/hooks/common/useDialog';
-import Modal, { type ModalInfo } from './Modal';
+import Modal, { type ModalInfo } from '../ui/Modal';
 
 type Props = {
   letter: Letter;

--- a/src/components/questions/CreateQuestionButton.tsx
+++ b/src/components/questions/CreateQuestionButton.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from 'next/router';
+import Button from '../ui/Button';
+import useDialog from '@/hooks/common/useDialog';
+import Popover from '../ui/Popover';
+
+export default function CreateQuestionButton() {
+  const router = useRouter();
+  const {
+    isOpen,
+    closeDialog: closePopover,
+    openDialog: openPopover,
+  } = useDialog();
+
+  return (
+    <div className="flex flex-col items-end h-20 mb-5">
+      <Button
+        variant="ghost"
+        size="xs"
+        onClick={openPopover}
+        className="w-6 mb-2 mr-8 text-gray"
+      >
+        ?
+      </Button>
+      <Button
+        onClick={() => {
+          router.push('/questions/new');
+        }}
+        variant="primary"
+        size="wide"
+      >
+        질문 직접 등록하기
+      </Button>
+      <Popover isOpen={isOpen} closePopover={closePopover}>
+        <div className="w-[90%] mx-auto text-sm my-6 ">
+          <p className="mb-5 text-lg font-bold text-center">
+            우리 커플을 위한 질문을 직접 등록해볼 수 있어요!
+          </p>
+          <p className="text-base text-accent">질문 예시 :</p>
+          <p>우리 00일에 뭐할까?</p>
+          <p>같이 제주도여행 갔을 때 가장 좋았던 장소는 어디였어?</p>
+        </div>
+      </Popover>
+    </div>
+  );
+}

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,4 @@
-import Dialog from '../ui/Dialog';
+import Dialog from './Dialog';
 
 export type ModalInfo = {
   actionText: string;

--- a/src/components/ui/Popover.tsx
+++ b/src/components/ui/Popover.tsx
@@ -1,0 +1,14 @@
+import Dialog from './Dialog';
+
+type Props = {
+  isOpen: boolean;
+  closePopover: () => void;
+  children: React.ReactNode;
+};
+export default function Popover({ isOpen, closePopover, children }: Props) {
+  return (
+    <Dialog isOpen={isOpen} closeDialog={closePopover}>
+      {children}
+    </Dialog>
+  );
+}

--- a/src/pages/questions/index.tsx
+++ b/src/pages/questions/index.tsx
@@ -12,6 +12,7 @@ import { createServerSideInstance, fetchData } from '@/libs/serversideApi';
 import { disallowAccess } from '@/util/disallowAccess';
 import { queryKeys } from '@/constants/queryKeys';
 import SEO from '@/components/SEO/SEO';
+import CreateQuestionButton from '@/components/questions/CreateQuestionButton';
 
 type Questions = {
   questions: Question[];
@@ -47,7 +48,8 @@ const Page: NextPageWithLayout<Questions> = () => {
         title="질문 선택"
         description="서로에 대해 더 알아가고 싶은 질문들을 탐색하세요. 질문을 통해 깊은 대화를 시작해 보세요."
       />
-      <div className="pt-8">
+      <div className="pt-3">
+        <CreateQuestionButton />
         {questionList.map((question) => (
           <div
             key={question.questionId}
@@ -97,6 +99,3 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 }
 
 export default Page;
-
-// 질문 직접 등록 버튼 설명
-// 질문 추가 규칙 설명


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용
- 질문 선택 페이지에 질문 직접 등록하기 버튼 추가(질문 등록 페이지로 이동)
- 질문 직접 등록 기능을 설명하는 popover 컴포넌트 추가 